### PR TITLE
CORE-6067: url-encode path parts in anon-files URLs sent to the UI

### DIFF
--- a/src/data_info/services/sharing.clj
+++ b/src/data_info/services/sharing.clj
@@ -148,7 +148,7 @@
 (defn anon-file-url
   [p]
   (let [aurl (url/url (cfg/anon-files-base))]
-    (str (-> aurl (assoc :path (ft/path-join (:path aurl) (string/replace p #"^\/" "")))))))
+    (str (-> aurl (assoc :path (apply ft/path-join (:path aurl) (map url/url-encode (string/split (string/replace p #"^\/" "") #"\/"))))))))
 
 (defn- anon-files-urls
   [paths]

--- a/src/data_info/services/sharing.clj
+++ b/src/data_info/services/sharing.clj
@@ -148,7 +148,7 @@
 (defn anon-file-url
   [p]
   (let [aurl (url/url (cfg/anon-files-base))]
-    (str (-> aurl (assoc :path (apply ft/path-join (:path aurl) (map url/url-encode (string/split (string/replace p #"^\/" "") #"\/"))))))))
+    (str (-> aurl (assoc :path (apply ft/path-join (:path aurl) (map url/url-encode (string/split (string/replace p #"^/" "") #"/"))))))))
 
 (defn- anon-files-urls
   [paths]


### PR DESCRIPTION
At least some genome browsers do funny stuff with spaces, so it's better to have this be a totally bona-fide URL with escaping and such. I'm doing the split-then-rejoin thing because we don't want to encode slashes, though.