### PR TITLE
Throw appropriate ERR_DOES_NOT_EXIST when data-info.services.uuids/path-for-uuid is used

### DIFF
--- a/src/data_info/services/uuids.clj
+++ b/src/data_info/services/uuids.clj
@@ -12,7 +12,7 @@
            [clojure.lang IPersistentMap]))
 
 
-(defn ^IPersistentMap path-for-uuid
+(defn path-for-uuid
   "Resolves a path for the entity with a given UUID.
 
    Params:
@@ -22,7 +22,9 @@
    Returns:
      It returns a path."
   ([^IPersistentMap cm ^String user ^UUID uuid]
-   (uuid/get-path cm uuid))
+   (if-let [path (uuid/get-path cm uuid)]
+     path
+     (throw+ {:error_code error/ERR_DOES_NOT_EXIST :uuid uuid})))
   ([^String user ^UUID uuid]
    (irods/with-jargon-exceptions [cm]
        (path-for-uuid cm user uuid))))

--- a/src/data_info/services/uuids.clj
+++ b/src/data_info/services/uuids.clj
@@ -39,9 +39,7 @@
    Returns:
      It returns a path-stat map containing an additional UUID field."
   ([^IPersistentMap cm ^String user ^UUID uuid]
-    (if-let [path (uuid/get-path cm uuid)]
-      (assoc (stat/path-stat cm user path) :uuid uuid)
-      (throw+ {:error_code error/ERR_DOES_NOT_EXIST :uuid uuid})))
+    (assoc (stat/path-stat cm user (path-for-uuid cm user uuid)) :uuid uuid))
 
   ([^String user ^UUID uuid]
    (irods/with-jargon-exceptions [cm]


### PR DESCRIPTION
This caused a regression error at (at least): https://shimerdas.iplantcollaborative.org:8443/job/DE_QA-3/237/robot/report/log.html#s1-s4-s44-t25-k9

I didn't check if there were other places in the regression this affected, but I did check that all places that use `path-for-uuid` should be throwing an error when the UUID they're calling it for doesn't exist.