### PR TITLE
CORE-7813 Add GET /navigation/base-paths

### DIFF
--- a/src/data_info/routes/navigation.clj
+++ b/src/data_info/routes/navigation.clj
@@ -13,6 +13,16 @@
   (context "/navigation" []
     :tags ["navigation"]
 
+    (GET "/base-paths" [:as {uri :uri}]
+      :query [{:keys [user]} StandardUserQueryParams]
+      :return UserBasePaths
+      :summary "Get User's Base Paths"
+      :description (str
+"This endpoint returns the base paths of the user's home directory, trash, and the base trash path."
+(get-error-code-block
+  "ERR_NOT_A_USER"))
+      (svc/trap uri root/user-base-paths user))
+
     (GET "/home" [:as {uri :uri}]
       :query [params StandardUserQueryParams]
       :return RootListing

--- a/src/data_info/routes/schemas/navigation.clj
+++ b/src/data_info/routes/schemas/navigation.clj
@@ -3,11 +3,17 @@
         [data-info.routes.schemas.stats])
   (:require [schema.core :as s]))
 
+(s/defschema UserBasePaths
+  {:user_home_path  (describe String "The absolute path to the user's home folder")
+   :user_trash_path (describe String "The absolute path to the user's trash folder")
+   :base_trash_path (describe String "The absolute path to the base trash folder")})
+
 (s/defschema RootListing
   (dissoc DataStatInfo :type))
 
 (s/defschema NavigationRootResponse
-  {:roots [RootListing]})
+  {:roots      [RootListing]
+   :base-paths UserBasePaths})
 
 (s/defschema FolderListing
   (-> DataStatInfo


### PR DESCRIPTION
This PR adds a new `GET /navigation/base-paths` endpoint that returns the absolute paths of the user's home directory, trash, and the base trash path:
```json
{
  "user_home_path": "string",
  "user_trash_path": "string",
  "base_trash_path": "string"
}
```

This information was previously generated by terrain's `bootstrap` endpoint, but terrain will now defer to this endpoint for this info.

Also updated `GET /navigation/root` to include a `base-paths` field, which includes this info as well. This will help the UI retrieve this info later if the `bootstrap` endpoint could not initially retrieve it at user login.