### PR TITLE
CORE-8487 Update to new protocol version of metadata-client

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,7 @@
                  [org.cyverse/common-swagger-api "2.8.1"]
                  [org.cyverse/heuristomancer "2.8.0"]
                  [org.cyverse/kameleon "3.0.0"]
-                 [org.cyverse/metadata-client "2.8.1"]
+                 [org.cyverse/metadata-client "2.8.2-SNAPSHOT"]
                  [org.cyverse/service-logging "2.8.0"]
                  [org.cyverse/tree-urls-client "2.8.1"]
                  [org.cyverse/event-messages "0.0.1"]

--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,7 @@
                  [org.cyverse/common-swagger-api "2.8.1"]
                  [org.cyverse/heuristomancer "2.8.0"]
                  [org.cyverse/kameleon "3.0.0"]
-                 [org.cyverse/metadata-client "2.8.2-SNAPSHOT"]
+                 [org.cyverse/metadata-client "3.0.0"]
                  [org.cyverse/service-logging "2.8.0"]
                  [org.cyverse/tree-urls-client "2.8.1"]
                  [org.cyverse/event-messages "0.0.1"]

--- a/src/data_info/clients/metadata.clj
+++ b/src/data_info/clients/metadata.clj
@@ -1,0 +1,19 @@
+(ns data-info.clients.metadata
+  (:require [data-info.util.config :as config]
+            [metadata-client.core :as metadata-client]))
+
+(defn list-avus
+  [user data-type data-id]
+  (metadata-client/list-avus (config/metadata-client) user data-type data-id {:as :json}))
+
+(defn update-avus
+  [user data-type data-id body]
+  (metadata-client/update-avus (config/metadata-client) user data-type data-id body))
+
+(defn set-avus
+  [user data-type data-id body]
+  (metadata-client/set-avus (config/metadata-client) user data-type data-id body))
+
+(defn copy-metadata-avus
+  [user data-type data-id dest-items]
+  (metadata-client/copy-metadata-avus (config/metadata-client) user data-type data-id dest-items))

--- a/src/data_info/routes/avus.clj
+++ b/src/data_info/routes/avus.clj
@@ -1,7 +1,6 @@
 (ns data-info.routes.avus
   (:use [common-swagger-api.routes]
         [common-swagger-api.schema]
-        [data-info.routes.middleware :only [wrap-metadata-base-url]]
         [data-info.routes.schemas.common]
         [data-info.routes.schemas.avus])
   (:require [data-info.services.metadata :as meta]
@@ -15,7 +14,6 @@
     (GET "/metadata" [:as {uri :uri}]
       :query [{:keys [user]} StandardUserQueryParams]
       :return AVUGetResult
-      :middleware [wrap-metadata-base-url]
       :summary "List AVUs (administrative)"
       :description
           (str "List all AVUs associated with a data item. Include administrative/system iRODS AVUs.
@@ -32,7 +30,6 @@
       :query [{:keys [user]} StandardUserQueryParams]
       :body [body (describe AddMetadataRequest "The iRODS and Metadata AVUs to add")]
       :return AVUChangeResult
-      :middleware [wrap-metadata-base-url]
       :summary "Add AVUs (administrative)"
       :description
             (str "Associate iRODS and Metadata AVUs with a data item. Allow adding any AVU.
@@ -52,7 +49,6 @@
     (GET "/metadata" [:as {uri :uri}]
       :query [{:keys [user]} StandardUserQueryParams]
       :return AVUGetResult
-      :middleware [wrap-metadata-base-url]
       :summary "List AVUs"
       :description
           (str "List all AVUs associated with a data item.
@@ -69,7 +65,6 @@
       :query [{:keys [user]} StandardUserQueryParams]
       :body [body (describe AddMetadataRequest "The iRODS and Metadata AVUs to add")]
       :return AVUChangeResult
-      :middleware [wrap-metadata-base-url]
       :summary "Add AVUs"
       :description
             (str "Associate iRODS and Metadata AVUs with a data item.
@@ -89,7 +84,6 @@
                             "A list of AVUs to set for this file.
                              May not include administrative AVUs, and will not delete them.")]
       :return AVUChangeResult
-      :middleware [wrap-metadata-base-url]
       :summary "Set AVUs"
       :description
            (str "Set the iRODS and metadata AVUS for a data item to a provided set.
@@ -108,7 +102,6 @@
       :query [{:keys [user]} StandardUserQueryParams]
       :body [{:keys [destination_ids]} (describe MetadataCopyRequest "The destination data items.")]
       :return MetadataCopyResult
-      :middleware [wrap-metadata-base-url]
       :summary "Copy Metadata"
       :description
            (str "Copies all IRODS AVUs visible to the client and Metadata AVUs from the data
@@ -122,7 +115,6 @@
     (POST "/metadata/csv-parser" [:as {uri :uri}]
       :query [params MetadataCSVParseParams]
       :return MetadataCSVParseResult
-      :middleware [wrap-metadata-base-url]
       :summary "Add Batch Metadata from CSV File"
       :description
            (str "This endpoint will parse a CSV/TSV file of metadata to apply to data items.

--- a/src/data_info/routes/data.clj
+++ b/src/data_info/routes/data.clj
@@ -1,7 +1,6 @@
 (ns data-info.routes.data
   (:use [common-swagger-api.routes]
         [common-swagger-api.schema]
-        [data-info.routes.middleware :only [wrap-metadata-base-url]]
         [data-info.routes.schemas.common]
         [data-info.routes.schemas.data]
         [data-info.routes.schemas.stats])
@@ -145,7 +144,6 @@ with characters in a runtime-configurable parameter. Currently, this parameter l
         :query [params StandardUserQueryParams]
         :body [body (describe MetadataSaveRequest "The metadata save request.")]
         :return FileStat
-        :middleware [wrap-metadata-base-url]
         :summary "Exporting Metadata to a File"
         :description (str
   "Exports file/folder details in a JSON format (similar to the /stat-gatherer endpoint response),

--- a/src/data_info/routes/middleware.clj
+++ b/src/data_info/routes/middleware.clj
@@ -1,7 +1,0 @@
-(ns data-info.routes.middleware
-  (:require [data-info.util.config :as config]
-            [metadata-client.middleware :as client-middleware]))
-
-(defn wrap-metadata-base-url
-  [handler]
-  (client-middleware/wrap-metadata-base-url handler config/metadata-base-url))

--- a/src/data_info/services/metadata.clj
+++ b/src/data_info/services/metadata.clj
@@ -10,7 +10,7 @@
             [clojure.set :as s]
             [clojure-commons.file-utils :as ft]
             [cheshire.core :as json]
-            [dire.core :refer [with-pre-hook! with-post-hook!]]
+            [data-info.clients.metadata :as metadata]
             [data-info.services.directory :as directory]
             [data-info.services.page-tabular :as csv]
             [data-info.services.stat :as stat]
@@ -19,7 +19,7 @@
             [data-info.util.irods :as irods]
             [data-info.util.paths :as paths]
             [data-info.util.validators :as validators]
-            [metadata-client.core :as metadata]))
+            [dire.core :refer [with-pre-hook! with-post-hook!]]))
 
 
 (defn- fix-unit
@@ -83,7 +83,7 @@
   (irods/with-jargon-exceptions [cm]
     (validators/user-exists cm user)
     (let [{:keys [path type]} (get-readable-data-item cm user data-id)
-          metadata-response   (metadata/list-avus user (resolve-data-type type) data-id :as :json)]
+          metadata-response   (metadata/list-avus user (resolve-data-type type) data-id)]
       (merge (:body metadata-response)
              {:irods-avus (list-path-metadata cm path :system system)
               :path       path}))))
@@ -245,7 +245,7 @@
    subfolders (plus all their files and subfolders) with their metadata in the resulting stat map."
   [cm user recursive? {:keys [id path type] :as data-item}]
   (let [irods-metadata (list-path-metadata cm path)
-        metadata-avus (-> (metadata/list-avus user (resolve-data-type type) (uuidify id) :as :json)
+        metadata-avus (-> (metadata/list-avus user (resolve-data-type type) (uuidify id))
                           :body
                           :avus)
         data-item (assoc data-item :metadata (concat irods-metadata metadata-avus))

--- a/src/data_info/util/config.clj
+++ b/src/data_info/util/config.clj
@@ -4,7 +4,8 @@
             [clojure-commons.config :as cc]
             [clojure-commons.error-codes :as ce]
             [clojure.tools.logging :as log]
-            [common-cfg.cfg :as cfg]))
+            [common-cfg.cfg :as cfg]
+            [metadata-client.core :as metadata-client]))
 
 (def docs-uri "/docs")
 
@@ -266,6 +267,9 @@
 (defn- exception-filters
   []
   (remove nil? [(icat-password) (icat-user) (irods-password) (irods-user)]))
+
+(def metadata-client
+  (memoize #(metadata-client/new-metadata-client (metadata-base-url))))
 
 (def anon-files-base
   (memoize


### PR DESCRIPTION
Updates for the new protocol version of `metadata-client` added by cyverse-de/metadata-client#1.

Includes a new `data-info.clients.metadata` to facade calls to `metadata-client`.