### PR TITLE
CORE-8949 Prevent potential "Too many open files" error.

### DIFF
--- a/src/data_info/util/irods.clj
+++ b/src/data_info/util/irods.clj
@@ -11,7 +11,7 @@
             [data-info.util.config :as cfg])
   (:import [clojure.lang IPersistentMap]
            [java.util UUID]
-           [java.io IOException]
+           [java.io IOException InputStream]
            [org.irods.jargon.core.exception JargonException]
            [org.apache.tika Tika]))
 
@@ -60,6 +60,10 @@
       (throw+ {:error_code error/ERR_NOT_FOUND :path path}))
     (-> attrs first :value UUID/fromString)))
 
+(defn- detect-media-type-from-contents
+  [^IPersistentMap cm ^String path]
+  (with-open [^InputStream istream (ops/input-stream cm path)]
+    (.detect (Tika.) istream)))
 
 (defn ^String detect-media-type
   "detects the media type of a given file
@@ -74,7 +78,7 @@
    (let [path-type (.detect (Tika.) (file/basename path))]
      (if (or (= path-type "application/octet-stream")
              (= path-type "text/plain"))
-       (.detect (Tika.) (ops/input-stream cm path))
+       (detect-media-type-from-contents cm path)
        path-type)))
 
   ([^String path]


### PR DESCRIPTION
Prevents potential `JargonException` "Unknown iRODS exception code recieved:-510024" in `stat-gatherer` and `metadata` save endpoints (and others?).