### PR TITLE
CORE-8945 Add `POST /path-list-creator`

### DIFF
--- a/data-info.properties.tmpl
+++ b/data-info.properties.tmpl
@@ -35,8 +35,9 @@
 # file typing configuration
 data-info.type-detect.type-attribute = {{ (key (printf "%s/data-info/type-detect-attribute" $base)) }}
 
-# HT Path List File Identifier
+# HT Path List Files
 data-info.path-list.file-identifier = {{ key (printf "%s/de/file-identifier" $base) }}
+data-info.path-list.info-type       = {{ key (printf "%s/apps/path-list-info-type" $base) }}
 
 # AMQP configuration
 {{ with $v := (key (printf "%s/amqp/uri" $base)) }}data-info.amqp.uri = {{ $v }}{{ end }}

--- a/data-info.properties.tmpl
+++ b/data-info.properties.tmpl
@@ -35,6 +35,9 @@
 # file typing configuration
 data-info.type-detect.type-attribute = {{ (key (printf "%s/data-info/type-detect-attribute" $base)) }}
 
+# HT Path List File Identifier
+data-info.path-list.file-identifier = {{ key (printf "%s/de/file-identifier" $base) }}
+
 # AMQP configuration
 {{ with $v := (key (printf "%s/amqp/uri" $base)) }}data-info.amqp.uri = {{ $v }}{{ end }}
 {{- end }}

--- a/src/data_info/routes.clj
+++ b/src/data_info/routes.clj
@@ -11,6 +11,7 @@
             [data-info.routes.data :as data-routes]
             [data-info.routes.exists :as exists-routes]
             [data-info.routes.filetypes :as filetypes-routes]
+            [data-info.routes.path-lists :as path-lists]
             [data-info.routes.permissions :as permission-routes]
             [data-info.routes.navigation :as navigation-routes]
             [data-info.routes.rename :as rename-routes]
@@ -56,6 +57,7 @@
     permission-routes/permissions-routes
     navigation-routes/navigation
     stat-routes/stat-gatherer
+    path-lists/path-list-creator
     sharing-routes/sharing-routes
     ticket-routes/ticket-routes
     trash-routes/trash

--- a/src/data_info/routes/path_lists.clj
+++ b/src/data_info/routes/path_lists.clj
@@ -1,0 +1,29 @@
+(ns data-info.routes.path-lists
+  (:use [common-swagger-api.schema]
+        [data-info.routes.schemas.common]
+        [data-info.routes.schemas.path-lists]
+        [data-info.routes.schemas.stats])
+  (:require [data-info.services.path-lists :as path-list-svc]
+            [data-info.util.service :as svc]))
+
+(defroutes path-list-creator
+  (context "/path-list-creator" []
+           :tags ["bulk"]
+
+    (POST "/" [:as {uri :uri}]
+          :query [params PathListSaveQueryParams]
+          :body [body (describe Paths "The folder or file paths to process for the HT Path List file contents.")]
+          :responses {200 {:schema      FileStat
+                           :description "File info for the saved HT Path List file."}}
+          :summary "Create an HT Path List File"
+          :description
+          (str
+            "Generates an HT Path List file for all paths under the given set of folder paths,
+             saving the results to the given destination file.
+             The paths for folders given in the request will not be included in the results,
+             but if any file paths are included in the request,
+             those paths will also be processed according to the other given parameters."
+            (get-error-code-block
+              "ERR_NOT_FOUND, ERR_EXISTS, ERR_DOES_NOT_EXIST, ERR_NOT_READABLE, ERR_NOT_WRITEABLE, ERR_NOT_A_USER,"
+              "ERR_BAD_PATH_LENGTH, ERR_BAD_DIRNAME_LENGTH, ERR_BAD_BASENAME_LENGTH"))
+          (svc/trap uri path-list-svc/create-path-list params body))))

--- a/src/data_info/routes/schemas/path_lists.clj
+++ b/src/data_info/routes/schemas/path_lists.clj
@@ -1,0 +1,28 @@
+(ns data-info.routes.schemas.path-lists
+  (:use [common-swagger-api.schema :only [describe NonBlankString StandardUserQueryParams]]
+        [data-info.routes.schemas.common])
+  (:require [schema.core :as s]))
+
+(s/defschema PathListSaveQueryParams
+  (merge StandardUserQueryParams
+         {:dest
+          (describe NonBlankString "An IRODS path to a destination file where the HT Path List contents will be saved")
+
+          (s/optional-key :name-pattern)
+          (describe NonBlankString
+                    "Specifying a regex pattern will filter the results to include
+                     only file/folder names that match that pattern")
+
+          (s/optional-key :info-type)
+          (describe [NonBlankString]
+                    "Specifying one or more info-types will filter the results to include
+                     only files with one of those info-types.")
+
+          (s/optional-key :folders-only)
+          (describe Boolean
+                    "When set to true, then only paths for folders will be included in the results,
+                     otherwise only file paths will be included.")
+
+          (s/optional-key :recursive)
+          (describe Boolean
+                    "When set to true, then paths under all subfolders will also be processed recursively")}))

--- a/src/data_info/services/filetypes.clj
+++ b/src/data_info/services/filetypes.clj
@@ -16,6 +16,12 @@
   []
   {:types script-types})
 
+(defn add-type-to-validated-path
+  "Adds the type to a file in iRODS at a path that has already been validated as existing/writable/etc.
+   e.g. when setting a type to a file that has just been created."
+  [cm path type]
+  (set-metadata cm path (cfg/type-detect-type-attribute) type ""))
+
 (defn- add-type
   "Adds the type to a file in iRODS at path for the specified user."
   [user path type]
@@ -25,7 +31,7 @@
     (validators/user-owns-path cm user path)
     (validators/path-is-file cm path)
 
-    (set-metadata cm path (cfg/type-detect-type-attribute) type "")
+    (add-type-to-validated-path cm path type)
     {:path path
      :type type
      :user user}))

--- a/src/data_info/services/path_lists.clj
+++ b/src/data_info/services/path_lists.clj
@@ -121,6 +121,8 @@
       (validators/path-writeable cm user dest-dir)
       (validators/path-not-exists cm dest)
       (validators/all-paths-exist cm paths)
+      (doseq [path paths]
+        (validators/not-base-path user path))
 
       (with-in-str (paths->ht-path-list cm user name-pattern info-type folders-only recursive paths)
                    {:file (stat/decorate-stat cm user (copy-stream cm *in* user dest) (stat/process-filters nil nil))}))))

--- a/src/data_info/services/path_lists.clj
+++ b/src/data_info/services/path_lists.clj
@@ -1,0 +1,124 @@
+(ns data-info.services.path-lists
+  (:use [clojure-commons.error-codes]
+        [clj-jargon.item-ops :only [copy-stream]]
+        [slingshot.slingshot :only [throw+]])
+  (:require [clojure.string :as string]
+            [clojure-commons.file-utils :as ft]
+            [clj-icat-direct.icat :as icat]
+            [clj-jargon.item-info :as item-info]
+            [clj-jargon.permissions :as perms]
+            [data-info.services.stat :as stat]
+            [data-info.util.config :as cfg]
+            [data-info.util.irods :as irods]
+            [data-info.util.validators :as validators]))
+
+(defn- stat-is-dir?
+  [{:keys [type]}]
+  (= :dir type))
+
+(defn- fmt-entry
+  [{:keys [uuid type full_path base_name info_type access_type_id]}]
+  {:id         uuid
+   :type       (case type "dataobject" :file "collection" :dir)
+   :path       full_path
+   :label      base_name
+   :infoType   info_type
+   :permission (perms/fmt-perm access_type_id)})
+
+(defn- filter-entity-type
+  [recursive? folders-only?]
+  (cond
+    (and recursive? (not folders-only?)) :any
+    folders-only?                        :folder
+    :else                                :file))
+
+(defn- folder-listing
+  "Fetches a folder's contents, listing files, folders, or both depending on the given parameters."
+  [user info-types folders-only? recursive? path]
+  (map fmt-entry
+       (icat/paged-folder-listing
+         :user           user
+         :zone           (cfg/irods-zone)
+         :folder-path    path
+         :info-types     info-types
+         :entity-type    (filter-entity-type recursive? folders-only?)
+         :sort-column    :full-path
+         :sort-direction :asc
+         :limit          nil
+         :offset         0)))
+
+(defn- list-item-with-subitems
+  [user info-types folders-only? recursive? {:keys [path] :as data-item}]
+  "If given a file, returns that file as the only item in a list.
+   If given a folder, returns that folder in a list, and the list may include the folder's subfolder/files
+   depending on the given parameters."
+  (let [sub-listing (when (and recursive? (stat-is-dir? data-item))
+                      (mapcat (partial list-item-with-subitems user info-types folders-only? recursive?)
+                              (folder-listing user info-types folders-only? recursive? path)))]
+    (concat [data-item] sub-listing)))
+
+(defn- keep-top-level-file?
+  "A filter predicate to keep only files with an info-type that matches one in the given `info-types` list,
+   or to keep all files if `info-types` is empty."
+  [info-types]
+  (if (empty? info-types)
+    (constantly true)
+    (comp (partial some (set info-types)) list :infoType)))
+
+(defn- label-matches?
+  "Returns true if the given `name-pattern` matches the given label, or if the given `name-pattern` is blank."
+  [name-pattern label]
+  (or (string/blank? name-pattern)
+      (re-find (re-pattern name-pattern) label)))
+
+(defn- keep-data-item?
+  "Returns true if the given `data-item` has permissions set,
+   its label passes the `label-matches?` check,
+   and if it's a file or folder depending on the given `folders-only?` flag."
+  [name-pattern folders-only? {:keys [label permission] :as data-item}]
+  (and permission
+       (label-matches? name-pattern label)
+       (if (stat-is-dir? data-item)
+         folders-only?
+         (not folders-only?))))
+
+(defn- paths->ht-path-list
+  "Filters the given paths and returns a string of these paths appended to an HT Path List header.
+   Throws an error if the filtering params result in no matching paths."
+  [cm user name-pattern info-types folders-only? recursive? paths]
+  (let [{folder-paths true file-paths false} (group-by (partial item-info/is-dir? cm) paths)
+        files          (->> file-paths
+                            (map (partial stat/path-stat cm user))
+                            (filter (keep-top-level-file? info-types)))
+        folders        (->> folder-paths
+                            (mapcat (partial folder-listing user info-types folders-only? recursive?))
+                            (mapcat (partial list-item-with-subitems user info-types folders-only? recursive?)))
+        filtered-paths (->> (concat files folders)
+                            (filter (partial keep-data-item? name-pattern folders-only?))
+                            (map :path))]
+
+    (when (empty? filtered-paths)
+      (throw+ {:error_code ERR_NOT_FOUND
+               :reason "No paths matched the request."}))
+
+    (string/join "\n" (concat [(cfg/path-list-file-identifier)] filtered-paths))))
+
+(defn create-path-list
+  "Creates an HT Path List file from the given set of paths and filtering params.
+   The resulting HT Path List file will contain only file or only folder paths (depending on the `folders-only` param),
+   but no paths of folders in the initial given list will be included.
+   If `recursive` is true, then all subfolders (plus all their files and subfolders)
+   of any given folder paths are parsed and filtered as well.
+   Throws an error if the filtering params result in no matching paths."
+  [{:keys [user dest name-pattern info-type folders-only recursive]} {:keys [paths]}]
+  (irods/with-jargon-exceptions :client-user user [cm]
+    (validators/user-exists cm user)
+    (let [dest-dir (ft/dirname dest)]
+      (validators/path-exists cm dest-dir)
+      (validators/path-writeable cm user dest-dir)
+      (validators/path-not-exists cm dest)
+      (validators/all-paths-exist cm paths)
+      (validators/all-paths-readable cm user paths)
+
+      (with-in-str (paths->ht-path-list cm user name-pattern info-type folders-only recursive paths)
+                   {:file (stat/decorate-stat cm user (copy-stream cm *in* user dest) (stat/process-filters nil nil))}))))

--- a/src/data_info/util/config.clj
+++ b/src/data_info/util/config.clj
@@ -221,6 +221,11 @@
 ; End of type detection configuration
 
 
+(cc/defprop-optstr path-list-file-identifier
+  "The header line that identifies a file's contents as an HT Path List file."
+  [props config-valid configs]
+  "data-info.path-list.file-identifier" "# application/vnd.de.path-list+csv; version=1")
+
 (cc/defprop-optstr amqp-uri
   "The URI to use for connections to the AMQP broker."
   [props config-valid configs]

--- a/src/data_info/util/config.clj
+++ b/src/data_info/util/config.clj
@@ -226,6 +226,11 @@
   [props config-valid configs]
   "data-info.path-list.file-identifier" "# application/vnd.de.path-list+csv; version=1")
 
+(cc/defprop-optstr path-list-info-type
+  "The info-type of an HT Path List file."
+  [props config-valid configs]
+  "data-info.path-list.info-type" "ht-analysis-path-list")
+
 (cc/defprop-optstr amqp-uri
   "The URI to use for connections to the AMQP broker."
   [props config-valid configs]

--- a/src/data_info/util/paths.clj
+++ b/src/data_info/util/paths.clj
@@ -31,17 +31,19 @@
   [path comparison]
   (apply = (map ft/rm-last-slash [path comparison])))
 
-(defn- user-trash-dir?
-  [user abs]
-  (dir-equal? abs (user-trash-path user)))
-(defn- sharing? [abs] (dir-equal? abs (cfg/irods-home)))
-(defn- community? [abs] (dir-equal? abs (cfg/community-data)))
+(defn user-trash-dir?
+  [user path]
+  (dir-equal? path (user-trash-path user)))
+
+(defn base-trash-path? [path] (dir-equal? path (base-trash-path)))
+(defn sharing? [path] (dir-equal? path (cfg/irods-home)))
+(defn community? [path] (dir-equal? path (cfg/community-data)))
 
 (defn path->label
   "Generates a label given an absolute path in iRODS."
-  [user id]
+  [user path]
   (cond
-    (user-trash-dir? user id)             "Trash"
-    (sharing? id)                         "Shared With Me"
-    (community? id)                       "Community Data"
-    :else                                 (ft/basename id)))
+    (user-trash-dir? user path) "Trash"
+    (sharing? path)             "Shared With Me"
+    (community? path)           "Community Data"
+    :else                       (ft/basename path)))

--- a/src/data_info/util/validators.clj
+++ b/src/data_info/util/validators.clj
@@ -11,7 +11,8 @@
             [clj-jargon.users :as user]
             [clj-jargon.by-uuid :as uuid]
             [clojure-commons.error-codes :as error]
-            [data-info.util.config :as cfg])
+            [data-info.util.config :as cfg]
+            [data-info.util.paths :as paths])
   (:import [clojure.lang IPersistentCollection]))
 
 
@@ -184,6 +185,13 @@
     (throw+ {:error_code error/ERR_NOT_A_FILE
              :path       (filterv #(not (item/is-file? cm %)) paths)})))
 
+(defn not-base-path
+  [user path]
+  (when (or (paths/user-trash-dir? user path)
+            (paths/base-trash-path? path)
+            (paths/sharing? path)   ;; currently the same as the base "home" path
+            (paths/community? path))
+    (throw+ {:error_code error/ERR_BAD_OR_MISSING_FIELD :path path})))
 
 (defn all-users-exist
   [cm users]

--- a/test/data_info/services/path_lists_tests.clj
+++ b/test/data_info/services/path_lists_tests.clj
@@ -1,0 +1,189 @@
+(ns data-info.services.path-lists-tests
+  (:use [clojure.test]))
+
+;; Re-def private functions so they can be tested in this namespace.
+(def keep-top-level-file? #'data-info.services.path-lists/keep-top-level-file?)
+(def label-matches?       #'data-info.services.path-lists/label-matches?)
+(def keep-data-item?      #'data-info.services.path-lists/keep-data-item?)
+
+
+(def top-level-files [{:type       :file,
+                       :path       "/root/no-perms.csv",
+                       :label      "no-perms.csv",
+                       :infoType   "csv"}
+                      {:type       :file,
+                       :path       "/root/file-top.txt",
+                       :label      "file-top.txt",
+                       :infoType   "raw",
+                       :permission :read}
+                      {:type       :file,
+                       :path       "/root/file-top.csv",
+                       :label      "file-top.csv",
+                       :infoType   "csv",
+                       :permission :read}])
+
+(def data-items (concat top-level-files
+                        [{:type       :dir,
+                          :path       "/root/folder-1",
+                          :label      "folder-1",
+                          :permission :read}
+                         {:type       :dir,
+                          :path       "/root/folder-1/no-perms",
+                          :label      "no-perms"}
+                         {:type       :dir,
+                          :path       "/root/folder-1/sub1",
+                          :label      "sub1",
+                          :permission :read}
+                         {:type       :dir,
+                          :path       "/root/folder-1/sub1/sub2",
+                          :label      "sub2",
+                          :permission :read}
+                         {:type       :dir,
+                          :path       "/root/folder-1/not-a-csv-folder",
+                          :label      "not-a-csv-folder",
+                          :permission :read}
+                         {:type       :file,
+                          :path       "/root/folder-1/no-perms/no-perms-sub.csv",
+                          :infoType   "csv",
+                          :label      "no-perms-sub.csv"}
+                         {:type       :file,
+                          :path       "/root/folder-1/file-1.txt",
+                          :label      "file-1.txt",
+                          :infoType   "raw",
+                          :permission :read}
+                         {:type       :file,
+                          :path       "/root/folder-1/not-a-csv-file",
+                          :label      "not-a-csv-file",
+                          :infoType   "raw",
+                          :permission :read}
+                         {:type       :file,
+                          :path       "/root/folder-1/sub1/file-1.csv",
+                          :label      "file-1.csv",
+                          :infoType   "csv",
+                          :permission :read}
+                         {:type       :file,
+                          :path       "/root/folder-1/sub1/file-2.txt",
+                          :label      "file-2.txt",
+                          :infoType   "raw",
+                          :permission :read}
+                         {:type       :file,
+                          :path       "/root/folder-1/sub1/sub2/file-2.csv",
+                          :label      "file-2.csv",
+                          :infoType   "csv",
+                          :permission :read}]))
+
+(defn- top-level-files->keep-top-level-file?->set
+  [info-types]
+  (->> top-level-files
+       (filter (keep-top-level-file? info-types))
+       (map :path)
+       set))
+
+(defn- data-items->label-matches?->set
+  [name-pattern]
+  (->> data-items
+       (filter #(label-matches? name-pattern (:label %)))
+       (map :path)
+       set))
+
+(defn- data-items->keep-data-item?->set
+  [name-pattern folders-only?]
+  (->> data-items
+       (filter (partial keep-data-item? name-pattern folders-only?))
+       (map :path)
+       set))
+
+
+(deftest test-keep-top-level-file?
+  (testing "keep-top-level-file? nil or empty info-types"
+    (is (= (top-level-files->keep-top-level-file?->set [])
+           (set (map :path top-level-files))))
+
+    (is (= (top-level-files->keep-top-level-file?->set nil)
+           (set (map :path top-level-files)))))
+
+  (testing "keep-top-level-file? csv"
+    (is (= (top-level-files->keep-top-level-file?->set ["csv"])
+           #{"/root/no-perms.csv"
+             "/root/file-top.csv"})))
+
+  (testing "keep-top-level-file? raw"
+    (is (= (top-level-files->keep-top-level-file?->set ["raw"])
+           #{"/root/file-top.txt"}))))
+
+
+(deftest test-label-matches?
+  (testing "label-matches? nil or blank"
+    (is (= (data-items->label-matches?->set nil)
+           (set (map :path data-items))))
+
+    (is (= (data-items->label-matches?->set "")
+           (set (map :path data-items)))))
+
+  (testing "label-matches? \\.txt$"
+    (is (= (data-items->label-matches?->set "\\.txt$")
+           #{"/root/file-top.txt"
+             "/root/folder-1/file-1.txt"
+             "/root/folder-1/sub1/file-2.txt"})))
+
+  (testing "label-matches? ^file"
+    (is (= (data-items->label-matches?->set "^file")
+           #{"/root/file-top.txt"
+             "/root/file-top.csv"
+             "/root/folder-1/file-1.txt"
+             "/root/folder-1/sub1/file-1.csv"
+             "/root/folder-1/sub1/file-2.txt"
+             "/root/folder-1/sub1/sub2/file-2.csv"})))
+
+  (testing "label-matches? sub"
+    (is (= (data-items->label-matches?->set "sub")
+           #{"/root/folder-1/sub1"
+             "/root/folder-1/sub1/sub2"
+             "/root/folder-1/no-perms/no-perms-sub.csv"})))
+
+  (testing "label-matches? csv"
+    (is (= (data-items->label-matches?->set "csv")
+           #{"/root/folder-1/not-a-csv-folder"
+             "/root/no-perms.csv"
+             "/root/file-top.csv"
+             "/root/folder-1/no-perms/no-perms-sub.csv"
+             "/root/folder-1/not-a-csv-file"
+             "/root/folder-1/sub1/file-1.csv"
+             "/root/folder-1/sub1/sub2/file-2.csv"}))))
+
+
+(deftest test-keep-data-item?
+  (testing "keep-data-item? all files"
+    (is (= (data-items->keep-data-item?->set "" false)
+           #{"/root/file-top.txt"
+             "/root/file-top.csv"
+             "/root/folder-1/file-1.txt"
+             "/root/folder-1/not-a-csv-file"
+             "/root/folder-1/sub1/file-1.csv"
+             "/root/folder-1/sub1/file-2.txt"
+             "/root/folder-1/sub1/sub2/file-2.csv"})))
+
+  (testing "keep-data-item? all folders"
+    (is (= (data-items->keep-data-item?->set nil true)
+           #{"/root/folder-1"
+             "/root/folder-1/not-a-csv-folder"
+             "/root/folder-1/sub1"
+             "/root/folder-1/sub1/sub2"})))
+
+  (testing "keep-data-item? sub folders"
+    (is (= (data-items->keep-data-item?->set "sub" true)
+           #{"/root/folder-1/sub1"
+             "/root/folder-1/sub1/sub2"})))
+
+  (testing "keep-data-item? \\.txt$ files"
+    (is (= (data-items->keep-data-item?->set "\\.txt$" false)
+           #{"/root/file-top.txt"
+             "/root/folder-1/file-1.txt"
+             "/root/folder-1/sub1/file-2.txt"})))
+
+  (testing "keep-data-item? csv files"
+    (is (= (data-items->keep-data-item?->set "csv" false)
+           #{"/root/file-top.csv"
+             "/root/folder-1/not-a-csv-file"
+             "/root/folder-1/sub1/file-1.csv"
+             "/root/folder-1/sub1/sub2/file-2.csv"}))))


### PR DESCRIPTION
This PR adds the `POST /path-list-creator` endpoint, which will generate an HT Path List file for all paths under the given set of folder paths, saving the results to the given destination file.

The paths for folders given in the request will not be included in the results, but if any file paths are included in the request, those paths will also be processed according to the other given parameters:
* `recursive`: When set to true, then paths under all subfolders will also be processed recursively.
* `folders-only`: When set to true, then only paths for folders will be included in the results, otherwise only file paths will be included.
* `name-pattern`: Specifying a regex pattern will filter the results to include only file/folder names that match this pattern.
* `info-type`: Specifying one or more info-types will filter the results to include only files with one of those info-types.