### PR TITLE
CORE-6259, CORE-7930: Add a user groups endpoint to data-info for use by the search services

### DIFF
--- a/src/data_info/routes.clj
+++ b/src/data_info/routes.clj
@@ -20,6 +20,7 @@
             [data-info.routes.stats :as stat-routes]
             [data-info.routes.tickets :as ticket-routes]
             [data-info.routes.trash :as trash-routes]
+            [data-info.routes.users :as users-routes]
             [data-info.util :as util]
             [data-info.util.config :as config]
             [data-info.util.service :as svc]
@@ -39,6 +40,7 @@
                    {:name "tickets", :description "Ticket Operations"}
                    {:name "bulk", :description "Bulk Operations"}
                    {:name "navigation", :description "Navigation"}
+                   {:name "users", :description "User Operations"}
                    {:name "filetypes", :description "File Type Metadata"}]}})
   (middleware
     [add-user-to-context
@@ -61,4 +63,5 @@
     sharing-routes/sharing-routes
     ticket-routes/ticket-routes
     trash-routes/trash
+    users-routes/users-routes
     (undocumented (route/not-found (svc/unrecognized-path-response)))))

--- a/src/data_info/routes/schemas/users.clj
+++ b/src/data_info/routes/schemas/users.clj
@@ -1,0 +1,11 @@
+(ns data-info.routes.schemas.users
+  (:use [common-swagger-api.schema :only [describe
+                                          NonBlankString
+                                          StandardUserQueryParams]]
+        [data-info.routes.schemas.common])
+  (:require [schema.core :as s]))
+
+(s/defschema QualifiedUser (describe NonBlankString "A qualified username like foo#bar"))
+(s/defschema UserGroupsReturn
+  {:user (describe QualifiedUser "The user as requested, but qualified")
+   :groups (describe [QualifiedUser] "The list of qualified group names of groups this user belongs to")})

--- a/src/data_info/routes/schemas/users.clj
+++ b/src/data_info/routes/schemas/users.clj
@@ -5,7 +5,7 @@
         [data-info.routes.schemas.common])
   (:require [schema.core :as s]))
 
-(s/defschema QualifiedUser (describe NonBlankString "A qualified username like foo#bar"))
+(def QualifiedUser NonBlankString)
 (s/defschema UserGroupsReturn
-  {:user (describe QualifiedUser "The user as requested, but qualified")
+  {:user (describe QualifiedUser "The user as requested, but qualified with iRODS zone")
    :groups (describe [QualifiedUser] "The list of qualified group names of groups this user belongs to")})

--- a/src/data_info/routes/users.clj
+++ b/src/data_info/routes/users.clj
@@ -1,0 +1,20 @@
+(ns data-info.routes.users
+  (:use [common-swagger-api.schema]
+        [data-info.routes.schemas.common]
+        [data-info.routes.schemas.users])
+  (:require [data-info.services.users :as users]
+            [data-info.util.service :as svc]))
+
+
+(defroutes users-routes
+  (context "/users" []
+    :tags ["users"]
+
+    (GET "/:username/groups" [:as {uri :uri}]
+      :path-params [username :- (describe String "The username whose groups should be listed")]
+      :query [{:keys [user]} StandardUserQueryParams]
+      :return UserGroupsReturn
+      :summary "Get a user's groups"
+      :description (str "Get a list of a user's groups, if the requesting user is allowed to see them"
+(get-error-code-block "ERR_NOT_A_USER"))
+         (svc/trap uri users/do-list-qualified-user-groups user username))))

--- a/src/data_info/routes/users.clj
+++ b/src/data_info/routes/users.clj
@@ -16,5 +16,5 @@
       :return UserGroupsReturn
       :summary "Get a user's groups"
       :description (str "Get a list of a user's groups, if the requesting user is allowed to see them"
-(get-error-code-block "ERR_NOT_A_USER"))
+                        (get-error-code-block "ERR_NOT_A_USER"))
          (svc/trap uri users/do-list-qualified-user-groups user username))))


### PR DESCRIPTION
This should be relatively straightforward to review. We need this because the search service needs to add a clause limiting the search to data the user can actually see. So, given a user, it needs a way to find the user's full qualified name a la `mian#iplant` and the qualified names of all the groups the user is part of, which can then be passed to the clause it adds to do that filtering.

I may or may not update terrain's existing search stuff to use this endpoint as well; it needs migration out of terrain for now, but the code that needs this won't be in terrain at all after the search refactor, so it might not be worth the bother.