### PR TITLE
CORE-9063 Add Multi-Input Path List identifier config settings.

### DIFF
--- a/data-info.properties.tmpl
+++ b/data-info.properties.tmpl
@@ -35,9 +35,11 @@
 # file typing configuration
 data-info.type-detect.type-attribute = {{ (key (printf "%s/data-info/type-detect-attribute" $base)) }}
 
-# HT Path List Files
-data-info.path-list.file-identifier = {{ key (printf "%s/de/file-identifier" $base) }}
-data-info.path-list.info-type       = {{ key (printf "%s/apps/path-list-info-type" $base) }}
+# Path List Files
+data-info.path-list.ht.file-identifier          = {{ key (printf "%s/data-info/ht-path-list-file-identifier" $base) }}
+data-info.path-list.ht.info-type                = {{ key (printf "%s/data-info/ht-path-list-info-type" $base) }}
+data-info.path-list.multi-input.file-identifier = {{ key (printf "%s/data-info/multi-input-path-list-file-identifier" $base) }}
+data-info.path-list.multi-input.info-type       = {{ key (printf "%s/data-info/multi-input-path-list-info-type" $base) }}
 
 # AMQP configuration
 {{ with $v := (key (printf "%s/amqp/uri" $base)) }}data-info.amqp.uri = {{ $v }}{{ end }}

--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-swagger-api "2.8.3"]
-                 [org.cyverse/heuristomancer "2.8.2"]
+                 [org.cyverse/heuristomancer "2.8.4"]
                  [org.cyverse/kameleon "3.0.2"]
                  [org.cyverse/metadata-client "3.0.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/data_info/routes/schemas/common.clj
+++ b/src/data_info/routes/schemas/common.clj
@@ -12,6 +12,7 @@
     " (clojure.string/join "\n    " error-codes)))
 
 (def DataIdPathParam (describe UUID "The data item's UUID"))
+(def ValidInfoTypes (conj (hm/supported-formats) "unknown"))
 
 (s/defschema Paths
   {:paths (describe [(s/one NonBlankString "path") NonBlankString] "A list of iRODS paths")})
@@ -26,6 +27,6 @@
   (-> (merge DataIds OptionalPaths)
       (->optional-param :ids)))
 
-(def ValidInfoTypesEnum (apply s/enum (conj (hm/supported-formats) "unknown")))
-(def ValidInfoTypesEnumPlusBlank (apply s/enum (conj (hm/supported-formats) "" "unknown")))
+(def ValidInfoTypesEnum (apply s/enum ValidInfoTypes))
+(def ValidInfoTypesEnumPlusBlank (apply s/enum (conj ValidInfoTypes "")))
 (def PermissionEnum (s/enum :read :write :own))

--- a/src/data_info/services/path_lists.clj
+++ b/src/data_info/services/path_lists.clj
@@ -106,7 +106,7 @@
       (throw+ {:error_code ERR_NOT_FOUND
                :reason "No paths matched the request."}))
 
-    (string/join "\n" (concat [(cfg/path-list-file-identifier)] filtered-paths))))
+    (string/join "\n" (concat [(cfg/ht-path-list-file-identifier)] filtered-paths))))
 
 (defn- validate-request-paths
   [cm user dest paths]
@@ -131,5 +131,5 @@
 
     (let [path-list-contents  (paths->ht-path-list cm user name-pattern info-type folders-only recursive paths)
           path-list-file-stat (with-in-str path-list-contents (copy-stream cm *in* user dest))]
-      (filetypes/add-type-to-validated-path cm dest (cfg/path-list-info-type))
+      (filetypes/add-type-to-validated-path cm dest (cfg/ht-path-list-info-type))
       {:file (stat/decorate-stat cm user path-list-file-stat (stat/process-filters nil nil))})))

--- a/src/data_info/util/config.clj
+++ b/src/data_info/util/config.clj
@@ -221,15 +221,25 @@
 ; End of type detection configuration
 
 
-(cc/defprop-optstr path-list-file-identifier
+(cc/defprop-optstr ht-path-list-file-identifier
   "The header line that identifies a file's contents as an HT Path List file."
   [props config-valid configs]
-  "data-info.path-list.file-identifier" "# application/vnd.de.path-list+csv; version=1")
+  "data-info.path-list.ht.file-identifier" "# application/vnd.de.path-list+csv; version=1")
 
-(cc/defprop-optstr path-list-info-type
+(cc/defprop-optstr ht-path-list-info-type
   "The info-type of an HT Path List file."
   [props config-valid configs]
-  "data-info.path-list.info-type" "ht-analysis-path-list")
+  "data-info.path-list.ht.info-type" "ht-analysis-path-list")
+
+(cc/defprop-optstr multi-input-path-list-identifier
+  "The header line that identifies a file's contents as a Multi-Input Path List file."
+  [props config-valid configs]
+  "data-info.path-list.multi-input.file-identifier" "# application/vnd.de.multi-input-path-list+csv; version=1")
+
+(cc/defprop-optstr multi-input-path-list-info-type
+  "The info-type of a Multi-Input Path List file."
+  [props config-valid configs]
+  "data-info.path-list.multi-input.info-type" "multi-input-path-list")
 
 (cc/defprop-optstr amqp-uri
   "The URI to use for connections to the AMQP broker."


### PR DESCRIPTION
This PR will add Multi-Input Path List identifier config settings and cleanup existing HT Path List config settings.

cyverse-de/heuristomancer#4 should be merged first.