### PR TITLE
CORE-9176: modified the OAI-ORE generation endoint to add an AVU to m…

### DIFF
--- a/src/data_info/services/metadata.clj
+++ b/src/data_info/services/metadata.clj
@@ -318,6 +318,7 @@
          ore-path
          (icat/list-files-under-folder path)
          (-> (metadata/list-avus user "folder" data-id) :body :avus)))
+      (add-metadata cm ore-path (cfg/ore-attribute) "true" "")
       nil)))
 
 (defn do-ore-save

--- a/src/data_info/util/config.clj
+++ b/src/data_info/util/config.clj
@@ -281,6 +281,11 @@
   [props config-valid configs]
   "data-info.commons.base" "http://datacommons.cyverse.org")
 
+(cc/defprop-optstr ore-attribute
+  "The attribute to tag OAI-ORE files with."
+  [props config-valid configs]
+  "data-info.ore-attr" "ipc-oai-ore")
+
 (defn- validate-config
   "Validates the configuration settings after they've been loaded."
   []


### PR DESCRIPTION
…ark the file for the DataONE services

This is a tiny change to add an AVU to any OAI-ORE file that is generated so that the DataONE services can easily look specifically for OAI-ORE files. I'm going to merge this change immediately, but reviews are still welcome.