### PR TITLE
CORE-9242: allow generated ORE files to be parsed by DataONE.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                  [org.cyverse/heuristomancer "2.8.4"]
                  [org.cyverse/kameleon "3.0.2"]
                  [org.cyverse/metadata-client "3.0.0"]
-                 [org.cyverse/oai-ore "1.0.1"]
+                 [org.cyverse/oai-ore "1.0.2-SNAPSHOT"]
                  [org.cyverse/service-logging "2.8.0"]
                  [org.cyverse/tree-urls-client "2.8.1"]
                  [org.cyverse/event-messages "0.0.1"]

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [net.sf.opencsv/opencsv "2.3"]
                  [de.ubercode.clostache/clostache "1.4.0" :exclusions [org.clojure/core.incubator]]
                  [slingshot "0.12.2"]
-                 [org.cyverse/clj-icat-direct "2.8.4"
+                 [org.cyverse/clj-icat-direct "2.8.5-SNAPSHOT"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [org.cyverse/clj-jargon "2.8.8"

--- a/src/data_info/services/metadata.clj
+++ b/src/data_info/services/metadata.clj
@@ -297,13 +297,18 @@
   ([{:keys [uuid]}]
    (str (curl/url (cfg/dataone-member-node-base) "v1" "object" uuid))))
 
+(defn- build-archived-file [{:keys [uuid] :as m}]
+  {:id  uuid
+   :uri (build-ore-uri m)})
+
 (defn- build-ore [cm writer agg-path ore-path files avus]
-  (xml/emit (ore/to-rdf (ore/build-ore
-                         (build-ore-uri cm agg-path)
-                         (build-ore-uri cm ore-path)
-                         (mapv build-ore-uri (remove (comp (partial = ore-path) :path) files))
-                         avus))
-            writer))
+  (let [ore-file-info? (comp (partial = ore-path) :path)]
+    (xml/emit (ore/to-rdf (ore/build-ore
+                           (build-ore-uri cm agg-path)
+                           (build-archived-file (first (filter ore-file-info? files)))
+                           (mapv build-archived-file (remove ore-file-info? files))
+                           avus))
+              writer)))
 
 (defn- ensure-file-exists
   "Ensures that a file exists at a given path."

--- a/src/data_info/services/metadata.clj
+++ b/src/data_info/services/metadata.clj
@@ -289,18 +289,20 @@
   [data-id {:keys [user]} {:keys [dest recursive]}]
   (metadata-save user (uuidify data-id) (ft/rm-last-slash dest) (boolean recursive)))
 
-(defn- build-ore-uri
-  "Creates a URI for an ORE aggregation from an iRODS path."
-  [path]
-  (str (curl/url (cfg/commons-base) "browse" (string/replace path #"^/+" ""))))
+(defn- ore-uri-builder
+  "Returns a function that can be used to create a URI for an ORE aggregation from an iRODS path."
+  [cm]
+  (fn [path]
+    (str (curl/url (cfg/dataone-member-node-base) "v1" "object" (irods/lookup-uuid cm path)))))
 
-(defn- build-ore [writer agg-path ore-path files avus]
-  (xml/emit (ore/to-rdf (ore/build-ore
-                         (build-ore-uri agg-path)
-                         (build-ore-uri ore-path)
-                         (mapv build-ore-uri (remove (partial = ore-path) files))
-                         avus))
-            writer))
+(defn- build-ore [cm writer agg-path ore-path files avus]
+  (let [build-ore-uri (ore-uri-builder cm)]
+    (xml/emit (ore/to-rdf (ore/build-ore
+                           (build-ore-uri agg-path)
+                           (build-ore-uri ore-path)
+                           (mapv build-ore-uri (remove (partial = ore-path) files))
+                           avus))
+              writer)))
 
 (defn- ore-save
   "Allows a data commons administrator to save an OAI-ORE file for a data set."
@@ -313,6 +315,7 @@
       (validators/path-writeable cm user path)
       (with-open [out (OutputStreamWriter. (output-stream cm ore-path))]
         (build-ore
+         cm
          out
          path
          ore-path

--- a/src/data_info/util/config.clj
+++ b/src/data_info/util/config.clj
@@ -276,10 +276,10 @@
   [props config-valid configs]
   "data-info.amqp.queue.auto-delete" false)
 
-(cc/defprop-optstr commons-base
-  "The base URL for the Data Commons web application."
+(cc/defprop-optstr dataone-member-node-base
+  "The base URL for the DataONE member node service."
   [props config-valid configs]
-  "data-info.commons.base" "http://datacommons.cyverse.org")
+  "data-info.dataone-member-node.base" "https://de.cyverse.org/dataone-node/rest/mn")
 
 (cc/defprop-optstr ore-attribute
   "The attribute to tag OAI-ORE files with."


### PR DESCRIPTION
I'm using snapshot versions of some libraries for the time being. I'll change them to real versions after all of the reviews are done and I deploy the release versions.