### PR TITLE
Allow tickets to be generated for paths with read permissions.

### DIFF
--- a/src/data_info/routes/schemas/tickets.clj
+++ b/src/data_info/routes/schemas/tickets.clj
@@ -8,17 +8,17 @@
 
 (s/defschema AddTicketQueryParams
   (assoc StandardUserQueryParams
-         (s/optional-key :mode)
-         (describe (s/enum :read :write)
-                   "Whether the created tickets allow `write` or `read` only access. Default is `read` only.")
+    (s/optional-key :mode)
+    (describe (s/enum :read :write)
+              "Whether the created tickets allow `write` or `read` only access. Default is `read` only.")
 
-         (s/optional-key :uses-limit)
-         (describe Long "Sets the `uses-limit` of the created tickets, when provided")
+    (s/optional-key :uses-limit)
+    (describe Long "Sets the `uses-limit` of the created tickets, when provided")
 
-         (s/optional-key :file-write-limit)
-         (describe Long "Sets the `file-write-limit` of the created tickets, when provided (10 by default)")
+    (s/optional-key :file-write-limit)
+    (describe Long "Sets the `file-write-limit` of the created tickets, when provided (10 by default)")
 
-         :public (describe Boolean "Whether the created tickets should be made public")))
+    :public (describe Boolean "Whether the created tickets should be made public")))
 
 (s/defschema TicketDefinition
   {:path (describe NonBlankString "The iRODS path for the ticket")

--- a/src/data_info/routes/schemas/tickets.clj
+++ b/src/data_info/routes/schemas/tickets.clj
@@ -18,7 +18,15 @@
     (s/optional-key :file-write-limit)
     (describe Long "Sets the `file-write-limit` of the created tickets, when provided (10 by default)")
 
-    :public (describe Boolean "Whether the created tickets should be made public")))
+    :public (describe Boolean "Whether the created tickets should be made public")
+
+    (s/optional-key :for-job)
+    (describe Boolean "Indicates whether the tickets are being created for an analysis")))
+
+(s/defschema DeleteTicketQueryParams
+  (assoc StandardUserQueryParams
+    (s/optional-key :for-job)
+    (describe Boolean "Indicates whether the tickets being deleted were created for an analysis")))
 
 (s/defschema TicketDefinition
   {:path (describe NonBlankString "The iRODS path for the ticket")

--- a/src/data_info/routes/tickets.clj
+++ b/src/data_info/routes/tickets.clj
@@ -34,7 +34,7 @@
 
   (POST "/ticket-deleter" [:as {uri :uri}]
     :tags ["tickets"]
-    :query [params StandardUserQueryParams]
+    :query [params DeleteTicketQueryParams]
     :body [body Tickets]
     :return DeleteTicketsResponse
     :summary "Delete tickets"


### PR DESCRIPTION
Submitting jobs to OSG requires the ability to generate read tickets for input files, and we don't want to prevent users from using input files for which they only have `read` permissions. The chosen solution, for the time being, is to allow these tickets to be generated only for the purpose of a job. We're using a query parameter to indicate that the ticket is being generated for a job, and the `apps` service will be modified to send the query parameter. Externally facing endpoints should not be modified to expose this parameter for the sake of security.
