### PR TITLE
CORE-11 Migrate /navigation/base-paths schemas

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  [org.cyverse/clojure-commons "2.8.3"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.9.3-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "2.11.7"]
                  [org.cyverse/heuristomancer "2.8.6"]
                  [org.cyverse/kameleon "3.0.2"]
                  [org.cyverse/metadata-client "3.0.0"]
@@ -66,7 +66,7 @@
   :main ^:skip-aot data-info.core
   :ring {:handler data-info.routes/app
          :init data-info.core/lein-ring-init
-         :port 60000
+         :port 31360
          :auto-reload? false}
   :uberjar-exclusions [#".*[.]SF" #"LICENSE" #"NOTICE"]
   :jvm-opts ["-Dlogback.configurationFile=/etc/iplant/de/logging/data-info-logging.xml"])

--- a/src/data_info/routes/navigation.clj
+++ b/src/data_info/routes/navigation.clj
@@ -1,5 +1,6 @@
 (ns data-info.routes.navigation
   (:use [common-swagger-api.schema]
+        [common-swagger-api.schema.data.navigation :only [UserBasePaths]]
         [data-info.routes.schemas.common]
         [data-info.routes.schemas.navigation]
         [data-info.routes.schemas.stats])

--- a/src/data_info/routes/schemas/navigation.clj
+++ b/src/data_info/routes/schemas/navigation.clj
@@ -1,12 +1,8 @@
 (ns data-info.routes.schemas.navigation
   (:use [common-swagger-api.schema :only [describe]]
+        [common-swagger-api.schema.data.navigation :only [UserBasePaths]]
         [data-info.routes.schemas.stats])
   (:require [schema.core :as s]))
-
-(s/defschema UserBasePaths
-  {:user_home_path  (describe String "The absolute path to the user's home folder")
-   :user_trash_path (describe String "The absolute path to the user's trash folder")
-   :base_trash_path (describe String "The absolute path to the base trash folder")})
 
 (s/defschema RootListing
   (dissoc DataStatInfo :type))


### PR DESCRIPTION
This PR will replace the `data-info.routes.schemas.navigation/UserBasePaths` schema with the schema added by cyverse-de/common-swagger-api#30.