### PR TITLE
CORE-9 Migrate ticket endpoint schemas and docs.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  [org.cyverse/clojure-commons "2.8.3"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.13-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "2.11.20"]
                  [org.cyverse/heuristomancer "2.8.6"]
                  [org.cyverse/kameleon "3.0.2"]
                  [org.cyverse/metadata-client "3.0.0"]

--- a/src/data_info/routes/schemas/tickets.clj
+++ b/src/data_info/routes/schemas/tickets.clj
@@ -1,67 +1,12 @@
 (ns data-info.routes.schemas.tickets
-  (:use [common-swagger-api.schema :only [describe
-                                          NonBlankString
-                                          StandardUserQueryParams]]
-        [data-info.routes.schemas.common])
-  (:require [schema.core :as s])
-  (:import [java.util UUID]))
+  (:use [common-swagger-api.schema :only [StandardUserQueryParams]])
+  (:require [common-swagger-api.schema.data.tickets :as schema]
+            [schema.core :as s]))
 
 (s/defschema AddTicketQueryParams
-  (assoc StandardUserQueryParams
-    (s/optional-key :mode)
-    (describe (s/enum :read :write)
-              "Whether the created tickets allow `write` or `read` only access. Default is `read` only.")
-
-    (s/optional-key :uses-limit)
-    (describe Long "Sets the `uses-limit` of the created tickets, when provided")
-
-    (s/optional-key :file-write-limit)
-    (describe Long "Sets the `file-write-limit` of the created tickets, when provided (10 by default)")
-
-    :public (describe Boolean "Whether the created tickets should be made public")
-
-    (s/optional-key :for-job)
-    (describe Boolean "Indicates whether the tickets are being created for an analysis")))
+  (merge StandardUserQueryParams
+         schema/AddTicketQueryParams))
 
 (s/defschema DeleteTicketQueryParams
-  (assoc StandardUserQueryParams
-    (s/optional-key :for-job)
-    (describe Boolean "Indicates whether the tickets being deleted were created for an analysis")))
-
-(s/defschema TicketDefinition
-  {:path (describe NonBlankString "The iRODS path for the ticket")
-   :ticket-id (describe NonBlankString "The ID of the ticket. Usually, but not always, a UUID.")
-   :download-url (describe NonBlankString "The URL for downloading the file associated with this ticket.")
-   :download-page-url (describe NonBlankString "The URL for managing this ticket, getting links, seeing metadata, etc.")})
-
-(s/defschema AddTicketResponse
-  {:user
-   (describe NonBlankString "The user performing the request.")
-
-   :tickets
-   (describe [TicketDefinition] "The tickets created")})
-
-(s/defschema ListTicketsResponseMap
-  {(describe s/Keyword "The iRODS data item's path")
-   (describe [TicketDefinition] "The tickets for this path")})
-
-(s/defschema ListTicketsResponse
-  {:tickets
-   (describe ListTicketsResponseMap "Map of tickets")})
-
-;; used only for documentation
-(s/defschema ListTicketsPathsMap
-  {:/path/from/request/to/a/file/or/folder
-   (describe [TicketDefinition] "The tickets for this path")})
-
-;; used only for documentation
-(s/defschema ListTicketsDocumentation
-  {:tickets
-   (describe [ListTicketsPathsMap] "the tickets")})
-
-(s/defschema Tickets
-  {:tickets (describe [NonBlankString] "A list of ticket IDs")})
-
-(s/defschema DeleteTicketsResponse
-  (assoc Tickets
-   :user (describe NonBlankString "The user performing the request.")))
+  (merge StandardUserQueryParams
+         schema/DeleteTicketQueryParams))

--- a/src/data_info/routes/tickets.clj
+++ b/src/data_info/routes/tickets.clj
@@ -1,8 +1,10 @@
 (ns data-info.routes.tickets
   (:use [common-swagger-api.schema]
-        [data-info.routes.schemas.common]
+        [data-info.routes.schemas.common :only [get-error-code-block]]
         [data-info.routes.schemas.tickets])
-  (:require [data-info.services.tickets :as tickets]
+  (:require [common-swagger-api.schema.data :as data-schema]
+            [common-swagger-api.schema.data.tickets :as schema]
+            [data-info.services.tickets :as tickets]
             [data-info.util.service :as svc]))
 
 
@@ -13,8 +15,8 @@
 
     (POST "/" [:as {uri :uri}]
       :query [params AddTicketQueryParams]
-      :body [body Paths]
-      :return AddTicketResponse
+      :body [body data-schema/Paths]
+      :return schema/AddTicketResponse
       :summary "Create tickets"
       :description (str
 "This endpoint allows creating tickets for a set of provided paths"
@@ -24,8 +26,8 @@
   (POST "/ticket-lister" [:as {uri :uri}]
     :tags ["tickets"]
     :query [params StandardUserQueryParams]
-    :body [body Paths]
-    :return (doc-only ListTicketsResponse ListTicketsDocumentation)
+    :body [body data-schema/Paths]
+    :return (doc-only schema/ListTicketsResponse schema/ListTicketsDocumentation)
     :summary "List tickets"
     :description (str
 "This endpoint lists tickets for a set of provided paths."
@@ -35,8 +37,8 @@
   (POST "/ticket-deleter" [:as {uri :uri}]
     :tags ["tickets"]
     :query [params DeleteTicketQueryParams]
-    :body [body Tickets]
-    :return DeleteTicketsResponse
+    :body [body schema/Tickets]
+    :return schema/DeleteTicketsResponse
     :summary "Delete tickets"
     :description (str
 "This endpoint deletes the provided set of tickets."

--- a/src/data_info/routes/tickets.clj
+++ b/src/data_info/routes/tickets.clj
@@ -1,11 +1,10 @@
 (ns data-info.routes.tickets
   (:use [common-swagger-api.schema]
-        [data-info.routes.schemas.common :only [get-error-code-block]]
-        [data-info.routes.schemas.tickets])
+        [data-info.routes.schemas.tickets]
+        [ring.util.http-response :only [ok]])
   (:require [common-swagger-api.schema.data :as data-schema]
             [common-swagger-api.schema.data.tickets :as schema]
-            [data-info.services.tickets :as tickets]
-            [data-info.util.service :as svc]))
+            [data-info.services.tickets :as tickets]))
 
 
 (defroutes ticket-routes
@@ -13,34 +12,28 @@
   (context "/tickets" []
     :tags ["tickets"]
 
-    (POST "/" [:as {uri :uri}]
+    (POST "/" []
       :query [params AddTicketQueryParams]
       :body [body data-schema/Paths]
-      :return schema/AddTicketResponse
-      :summary "Create tickets"
-      :description (str
-"This endpoint allows creating tickets for a set of provided paths"
-(get-error-code-block "ERR_NOT_A_USER, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_TOO_MANY_RESULTS"))
-      (svc/trap uri tickets/do-add-tickets params body)))
+      :responses schema/AddTicketResponses
+      :summary schema/AddTicketSummary
+      :description schema/AddTicketDocs
+      (ok (tickets/do-add-tickets params body))))
 
-  (POST "/ticket-lister" [:as {uri :uri}]
+  (POST "/ticket-lister" []
     :tags ["tickets"]
     :query [params StandardUserQueryParams]
     :body [body data-schema/Paths]
-    :return (doc-only schema/ListTicketsResponse schema/ListTicketsDocumentation)
-    :summary "List tickets"
-    :description (str
-"This endpoint lists tickets for a set of provided paths."
-(get-error-code-block "ERR_NOT_A_USER, ERR_DOES_NOT_EXIST, ERR_NOT_READABLE, ERR_TOO_MANY_RESULTS"))
-    (svc/trap uri tickets/do-list-tickets params body))
+    :responses schema/ListTicketResponses
+    :summary schema/ListTicketSummary
+    :description schema/ListTicketDocs
+    (ok (tickets/do-list-tickets params body)))
 
-  (POST "/ticket-deleter" [:as {uri :uri}]
+  (POST "/ticket-deleter" []
     :tags ["tickets"]
     :query [params DeleteTicketQueryParams]
     :body [body schema/Tickets]
-    :return schema/DeleteTicketsResponse
-    :summary "Delete tickets"
-    :description (str
-"This endpoint deletes the provided set of tickets."
-(get-error-code-block "ERR_NOT_A_USER, ERR_TICKET_DOES_NOT_EXIST, ERR_NOT_WRITEABLE"))
-    (svc/trap uri tickets/do-remove-tickets params body)))
+    :responses schema/DeleteTicketResponses
+    :summary schema/DeleteTicketSummary
+    :description schema/DeleteTicketDocs
+    (ok (tickets/do-remove-tickets params body))))


### PR DESCRIPTION
This PR will replace the ticket endpoint schemas and docs in `data-info.routes.schemas.tickets` and `data-info.routes.tickets` with those imported in cyverse-de/common-swagger-api#49.