### PR TITLE
CORE-919: moved most of the definition of FolderListingParams to comm…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  [org.cyverse/clojure-commons "2.8.3"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.27-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "2.11.27"]
                  [org.cyverse/heuristomancer "2.8.6"]
                  [org.cyverse/kameleon "3.0.2"]
                  [org.cyverse/metadata-client "3.0.0"]

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  [org.cyverse/clojure-commons "2.8.3"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.24"]
+                 [org.cyverse/common-swagger-api "2.11.27-SNAPSHOT"]
                  [org.cyverse/heuristomancer "2.8.6"]
                  [org.cyverse/kameleon "3.0.2"]
                  [org.cyverse/metadata-client "3.0.0"]

--- a/src/data_info/routes/schemas/data.clj
+++ b/src/data_info/routes/schemas/data.clj
@@ -5,10 +5,10 @@
                                           SortFieldDocs
                                           SortFieldOptionalKey
                                           StandardUserQueryParams]]
-        [common-swagger-api.schema.filetypes :only [ValidInfoTypesEnum]]
         [data-info.routes.schemas.common]
         [heuristomancer.core :as info])
-  (:require [schema.core :as s]))
+  (:require [common-swagger-api.schema.data :as data-schema]
+            [schema.core :as s]))
 
 (s/defschema PathToUUIDParams
   (assoc StandardUserQueryParams
@@ -40,34 +40,25 @@
 
 (s/defschema FolderListingParams
   (merge
-    StandardUserQueryParams
-    (assoc PagingParams
-      SortFieldOptionalKey
-      (describe (apply s/enum ValidSortFields) SortFieldDocs))
-    {(s/optional-key :entity-type)
-     (describe (s/enum :any :file :folder) "The type of folder items to include in the response.")
+   StandardUserQueryParams
+   data-schema/FolderListingParams
+   {(s/optional-key :bad-chars)
+    (describe String
+              "A list of characters which will mark a folder item's `badName` field to true if found in
+               that item's name.")
 
-     (s/optional-key :bad-chars)
-     (describe String
-       "A list of characters which will mark a folder item's `badName` field to true if found in
-        that item's name.")
+    (s/optional-key :bad-name)
+    (describe (s/either [String] String)
+              "A list of names which will mark a folder item's `badName` field to true if its name matches
+               any in the list.")
 
-     (s/optional-key :bad-name)
-     (describe (s/either [String] String)
-       "A list of names which will mark a folder item's `badName` field to true if its name matches
-        any in the list.")
+    (s/optional-key :bad-path)
+    (describe (s/either [String] String)
+              "A list of paths which will mark a folder item's `badName` field to true if its path matches
+               any in the list.")
 
-     (s/optional-key :bad-path)
-     (describe (s/either [String] String)
-       "A list of paths which will mark a folder item's `badName` field to true if its path matches
-        any in the list.")
-
-     (s/optional-key :info-type)
-     (describe (s/either [ValidInfoTypesEnum] ValidInfoTypesEnum)
-       "A list of info-types with which to filter a folder's result items.")
-
-     (s/optional-key :attachment)
-     (describe Boolean "Download file contents as attachment.")}))
+    (s/optional-key :attachment)
+    (describe Boolean "Download file contents as attachment.")}))
 
 (s/defschema TabularChunkParams
   (assoc

--- a/src/data_info/routes/schemas/data.clj
+++ b/src/data_info/routes/schemas/data.clj
@@ -31,13 +31,6 @@
       their files and subfolders) under the source folder will be included in the exported file,
       along with all of their metadata")})
 
-(def ValidSortFields
-  #{:datecreated
-    :datemodified
-    :name
-    :path
-    :size})
-
 (s/defschema FolderListingParams
   (merge
    StandardUserQueryParams

--- a/src/data_info/services/entry.clj
+++ b/src/data_info/services/entry.clj
@@ -11,7 +11,6 @@
             [clj-jargon.validations :as jv]
             [clojure-commons.error-codes :as error]
             [clojure-commons.file-utils :as file]
-            [data-info.routes.schemas.data :as domain]
             [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]
             [data-info.util.validators :as duv]
@@ -103,16 +102,18 @@
     :else                      info-type-params))
 
 
+(def ^:private database-column-from-sort-field
+  {:datecreated  :create-ts
+   :datemodified :modify-ts
+   :name         :base-name
+   :path         :full-path
+   :size         :data-size})
+
+
 (defn- resolve-sort-field
   [sort-field-param]
-  (if (and sort-field-param (contains? domain/ValidSortFields sort-field-param))
-    (case sort-field-param
-      :datecreated  :create-ts
-      :datemodified :modify-ts
-      :name         :base-name
-      :path         :full-path
-      :size         :data-size
-      sort-field-param)
+  (if sort-field-param
+    (database-column-from-sort-field sort-field-param sort-field-param)
     :base-name))
 
 


### PR DESCRIPTION
…on-swagger-api

I kept some of the query parameters out of `common-swagger-api` because they aren't used anywhere else.
