### PR TITLE
Async delete and restore (CORE-558 part 2)

### DIFF
--- a/src/data_info/clients/async_tasks.clj
+++ b/src/data_info/clients/async_tasks.clj
@@ -3,6 +3,7 @@
   (:require [data-info.util.config :as config]
             [data-info.util.irods :as irods]
             [clojure.tools.logging :as log]
+            [clojure.string :as string]
             [async-tasks-client.core :as async-tasks-client]))
 
 
@@ -33,6 +34,12 @@
 (defn get-by-filter
   [filters]
   (async-tasks-client/get-by-filter (config/async-tasks-client) filters))
+
+(defn run-async-thread
+  [async-task-id thread-function prefix]
+  (let [^Runnable task-thread (fn [] (thread-function async-task-id))]
+    (.start (Thread. task-thread (str prefix "-" (string/replace async-task-id #".*/tasks/" "")))))
+  async-task-id)
 
 (defn paths-async-thread
   [async-task-id jargon-fn]

--- a/src/data_info/routes/schemas/trash.clj
+++ b/src/data_info/routes/schemas/trash.clj
@@ -17,7 +17,10 @@
   (describe RestoredFile "The restored file information.")})
 
 (s/defschema Restoration
-  {:restored (describe RestorationMap "A map of paths from the request to their restoration info")})
+  {:restored (describe RestorationMap "A map of paths from the request to their restoration info")
+
+   (s/optional-key :async-task-id)
+   (describe NonBlankString "An asynchronous task ID for the delete process being handled in the background")})
 
 ;; Used only for display as documentation in Swagger UI
 (s/defschema RestorationPathsMap
@@ -27,7 +30,10 @@
 ;; Used only for display as documentation in Swagger UI
 (s/defschema RestorationPaths
   {:restored
-   (describe RestorationPathsMap "A map of paths from the request to their restoration info")})
+   (describe RestorationPathsMap "A map of paths from the request to their restoration info")
+
+   (s/optional-key :async-task-id)
+   (describe NonBlankString "An asynchronous task ID for the delete process being handled in the background")})
 
 (s/defschema TrashPathsMap
   {(describe s/Keyword "The iRODS data item's original path.")

--- a/src/data_info/routes/schemas/trash.clj
+++ b/src/data_info/routes/schemas/trash.clj
@@ -29,11 +29,9 @@
 
 ;; Used only for display as documentation in Swagger UI
 (s/defschema RestorationPaths
-  {:restored
-   (describe RestorationPathsMap "A map of paths from the request to their restoration info")
-
-   (s/optional-key :async-task-id)
-   (describe NonBlankString "An asynchronous task ID for the delete process being handled in the background")})
+  (assoc Restoration
+   :restored
+   (describe RestorationPathsMap "A map of paths from the request to their restoration info")))
 
 (s/defschema TrashPathsMap
   {(describe s/Keyword "The iRODS data item's original path.")

--- a/src/data_info/routes/schemas/trash.clj
+++ b/src/data_info/routes/schemas/trash.clj
@@ -6,7 +6,10 @@
 
 (s/defschema Trash
   (assoc OptionalPaths
-         :trash (describe String "The path of the trash directory that was emptied.")))
+         :trash (describe String "The path of the trash directory that was emptied.")
+
+         (s/optional-key :async-task-id)
+         (describe NonBlankString "An asynchronous task ID for the delete process being handled in the background")))
 
 (s/defschema RestoredFile
   {:restored-path (describe NonBlankString "The path the file was restored to.")

--- a/src/data_info/routes/schemas/trash.clj
+++ b/src/data_info/routes/schemas/trash.clj
@@ -35,7 +35,10 @@
 
 (s/defschema TrashPaths
   (assoc Paths
-         :trash-paths (describe TrashPathsMap "A map of paths from the request to their location in the trash, if any.")))
+         :trash-paths (describe TrashPathsMap "A map of paths from the request to their location in the trash, if any.")
+
+         (s/optional-key :async-task-id)
+         (describe NonBlankString "An asynchronous task ID for the delete process being handled in the background")))
 
 ;; Used only for documentation in Swagger UI
 (s/defschema TrashPathsDocMap

--- a/src/data_info/services/rename.clj
+++ b/src/data_info/services/rename.clj
@@ -31,7 +31,7 @@
                     (move cm (:source data) (:destination data) :user username :admin-users (cfg/irods-admins) :update-fn update-fn)))]
     (async-tasks/paths-async-thread async-task-id jargon-fn)))
 
-(defn- new-task
+(defn new-task
   [type user data]
   (async-tasks/create-task
     {:type type

--- a/src/data_info/services/rename.clj
+++ b/src/data_info/services/rename.clj
@@ -56,10 +56,9 @@
       (validators/user-owns-paths cm user sources)
       (validators/path-writeable cm user dest)
       (validators/no-paths-exist cm dest-paths))
-    (let [async-task-id (new-task "data-move" user {:sources sources :destination dest})
-          ^Runnable task-thread #(move-paths-thread async-task-id)]
-      (log/warn async-task-id)
-      (.start (Thread. task-thread (str "data-move-" async-task-id)))
+    (let [async-task-id (async-tasks/run-async-thread
+                          (new-task "data-move" user {:sources sources :destination dest})
+                          move-paths-thread "data-move")]
       {:user user :sources sources :dest dest :async-task-id async-task-id})))
 
 (defn- rename-path
@@ -80,10 +79,9 @@
           (if-not (= (ft/dirname source) (ft/dirname dest))
             (validators/path-writeable cm user (ft/dirname dest)))
           (validators/path-not-exists cm dest))
-        (let [async-task-id (new-task "data-rename" user {:source source :destination dest})
-              ^Runnable task-thread #(rename-path-thread async-task-id)]
-          (log/warn async-task-id)
-          (.start (Thread. task-thread (str "data-rename-" async-task-id)))
+        (let [async-task-id (async-tasks/run-async-thread
+                              (new-task "data-rename" user {:source source :destination dest})
+                              rename-path-thread "data-rename")]
           {:user user :source source :dest dest :async-task-id async-task-id})))))
 
 (defn- rename-uuid

--- a/src/data_info/services/trash.clj
+++ b/src/data_info/services/trash.clj
@@ -58,8 +58,6 @@
   (let [jargon-fn (fn [cm async-task update-fn]
                     (update-fn "deleted paths" :begin)
                     (let [{:keys [username data]} async-task]
-                      (log/info data)
-                      (log/info (:trash-paths data))
                       (doseq [^String p (:paths data)]
                         (update-fn p :begin-delete)
                         ;;; Delete all of the tickets associated with the file.

--- a/src/data_info/services/trash.clj
+++ b/src/data_info/services/trash.clj
@@ -208,8 +208,8 @@
                     (update-fn "deleted paths" :begin)
                     (let [{:keys [username data]} async-task]
                       (doseq [^String p (:paths data)]
-                        (let [fully-restored      (:restored-path ((:restoration-paths data) p))
-                              restored-to-homedir (:partial-restore ((:restoration-paths data) p))]
+                        (let [fully-restored      (:restored-path ((:restoration-paths data) (keyword p)))
+                              restored-to-homedir (:partial-restore ((:restoration-paths data) (keyword p)))]
                           (update-fn p :begin-restore)
                           (log/warn "Restoring " p " to " fully-restored)
 

--- a/src/data_info/services/trash.clj
+++ b/src/data_info/services/trash.clj
@@ -106,7 +106,6 @@
   "Delete by UUID: given a user and a data item UUID, delete that data item, returning a list of filenames deleted."
   [user source-uuid]
   (let [path (ft/rm-last-slash (uuids/path-for-uuid user source-uuid))]
-    (validate-not-homedir user [path])
     (delete-paths user [path])))
 
 (defn- delete-uuid-contents
@@ -255,8 +254,7 @@
 
 (with-pre-hook! #'do-delete
   (fn [params body]
-    (dul/log-call "do-delete" params body)
-    (validate-not-homedir (:user params) (:paths body))))
+    (dul/log-call "do-delete" params body)))
 
 (with-post-hook! #'do-delete (dul/log-func "do-delete"))
 

--- a/src/data_info/services/trash.clj
+++ b/src/data_info/services/trash.clj
@@ -107,7 +107,6 @@
   [user source-uuid]
   (let [path (ft/rm-last-slash (uuids/path-for-uuid user source-uuid))]
     (validate-not-homedir user [path])
-    (validators/validate-num-paths-under-folder user path)
     (delete-paths user [path])))
 
 (defn- delete-uuid-contents
@@ -115,7 +114,6 @@
   [user source-uuid]
   (irods/with-jargon-exceptions [cm]
     (let [source (ft/rm-last-slash (uuids/path-for-uuid cm user source-uuid))]
-      (validators/validate-num-paths-under-folder user source)
       (validators/path-is-dir cm source)
       (let [paths (directory/get-paths-in-folder user source)]
         (delete-paths cm user paths)))))
@@ -258,8 +256,7 @@
 (with-pre-hook! #'do-delete
   (fn [params body]
     (dul/log-call "do-delete" params body)
-    (validate-not-homedir (:user params) (:paths body))
-    (validators/validate-num-paths-under-paths (:user params) (:paths body))))
+    (validate-not-homedir (:user params) (:paths body))))
 
 (with-post-hook! #'do-delete (dul/log-func "do-delete"))
 
@@ -306,5 +303,4 @@
 
 (with-pre-hook! #'do-restore
   (fn [params body]
-    (dul/log-call "do-restore" params body)
-    (validators/validate-num-paths-under-paths (:user params) (:paths body))))
+    (dul/log-call "do-restore" params body)))

--- a/src/data_info/services/trash.clj
+++ b/src/data_info/services/trash.clj
@@ -76,7 +76,7 @@
                           (delete cm p true)) ;;; Force a delete to bypass proxy user's trash.
                         (update-fn p :end-delete)))
                     (update-fn "deleted paths" :end))]
-    (async-tasks/paths-async-thread async-task-id jargon-fn)))
+    (async-tasks/paths-async-thread async-task-id jargon-fn false))) ;; we don't use a client user so we can delete tickets
 
 (defn- delete-paths
   ([user paths]


### PR DESCRIPTION
Things included here:

* delete, restore, and delete-trash async
* number-of-path validators removed
* removing some extra, unneeded validators
* code reorganization/utility function stuff