### PR TITLE
CORE-1094: allow the path-info endpoint to optionally ignore missing or inaccessible paths or IDs

### DIFF
--- a/src/data_info/routes/schemas/stats.clj
+++ b/src/data_info/routes/schemas/stats.clj
@@ -15,4 +15,7 @@
   (merge StandardUserQueryParams
          stats-schema/FilteredStatQueryParams
          {(s/optional-key :ignore-missing)
-          (describe Boolean "If set to true missing paths or IDs will be ignored.")}))
+          (describe Boolean "If set to true, missing paths or data ids will be ignored.")
+
+          (s/optional-key :ignore-inaccessible)
+          (describe Boolean "If set to true, inaccessible paths or data ids will be ignored.")}))

--- a/src/data_info/routes/schemas/stats.clj
+++ b/src/data_info/routes/schemas/stats.clj
@@ -13,4 +13,6 @@
 
 (s/defschema FilteredStatQueryParams
   (merge StandardUserQueryParams
-         stats-schema/FilteredStatQueryParams))
+         stats-schema/FilteredStatQueryParams
+         {(s/optional-key :ignore-missing)
+          (describe Boolean "If set to true missing paths or IDs will be ignored.")}))


### PR DESCRIPTION
The purpose of this change is to speed up the permanent ID request endpoint in terrain. Terrain is currently performing a separate API call to get the path information for each permanent ID request, which can be sluggish when the data store is under a heavy load. As far as I can tell, the only reason that separate API calls are being made is because there's a chance that the paths related to some permanent ID requests either no longer exist or aren't accessible to the administrator doing the listing. Making separate API calls, allows terrain to effectively ignore errors for missing or inaccessible files. Allowing all of these requests to be combined into a single API call will speed things up dramatically.

The changes to the endpoint are as follows:

* Two new query parameters have been added `ignore-missing` and `ignore-inaccessible'.
* If neither query parameter is included in the request then the endpoint will work as it did before.
* If `ignore-missing` is set to `true` then paths or data IDs that don't exist will be ignored.
* If `ignore-inaccessible` is set to `true` then paths or data IDs that refer to files that the user can't access will be ignored.
* Ignored paths or data IDs are not included in the response body.
