### PR TITLE
Add notifications for async task completions

### DIFF
--- a/src/data_info/clients/async_tasks.clj
+++ b/src/data_info/clients/async_tasks.clj
@@ -42,9 +42,9 @@
   async-task-id)
 
 (defn paths-async-thread
-  ([async-task-id jargon-fn]
-   (paths-async-thread async-task-id jargon-fn true))
-  ([async-task-id jargon-fn use-client-user?]
+  ([async-task-id jargon-fn end-fn]
+   (paths-async-thread async-task-id jargon-fn end-fn true))
+  ([async-task-id jargon-fn end-fn use-client-user?]
    (let [{:keys [username] :as async-task} (get-by-id async-task-id)
          update-fn (fn [path action]
                      (log/info "Updating async task:" async-task-id ":" path action)
@@ -57,6 +57,8 @@
          (irods/with-jargon-exceptions [cm]
            (jargon-fn cm async-task update-fn)))
        (add-completed-status async-task-id {:status "completed"})
+       (end-fn async-task false)
        (catch Object _
          (log/error (:throwable &throw-context) "failed processing async task" async-task-id)
-         (add-completed-status async-task-id {:status "failed"}))))))
+         (add-completed-status async-task-id {:status "failed"})
+         (end-fn async-task true))))))

--- a/src/data_info/clients/notifications.clj
+++ b/src/data_info/clients/notifications.clj
@@ -1,0 +1,66 @@
+(ns data-info.clients.notifications
+  (:require [cheshire.core :as json]
+            [cemerick.url :as url]
+            [clj-http.client :as http]
+            [clojure-commons.file-utils :as ft]
+            [clojure.string :as string]
+            [data-info.util.paths :as paths]
+            [data-info.util.config :as config]))
+
+(defn send-notification
+  "Sends a notification to a user"
+  [message]
+  (let [notification-url (str (-> (url/url (config/notificationagent-base-url)) (assoc :path "/notification")))
+        res (http/post notification-url
+                       {:content-type :json
+                        :body (json/encode message)})]
+    res))
+
+(defn- amend-notification
+  [notification user action start-paths end-paths]
+  (assoc notification
+         :type "data"
+         :user user
+         :payload {:action action
+                   :paths end-paths}))
+
+(defn- completed-text
+  [failed?]
+  (if failed? "Failed" "Finished"))
+
+(defn move-notification
+  [user start-paths end-paths failed?]
+  (amend-notification
+    {:subject (str (completed-text failed?) " moving " (count start-paths) " file(s)/folder(s) to " (first end-paths))
+     :message (str (completed-text failed?) " moving " (string/join ", " start-paths) " to " (first end-paths))} 
+    user "move" start-paths end-paths))
+
+(defn rename-notification
+  [user start-paths end-paths failed?]
+  (amend-notification
+    {:subject (str (completed-text failed?) " renaming " (first start-paths) " to " (ft/basename (first end-paths)))
+     :message (str (completed-text failed?) " renaming " (first start-paths) " to " (first end-paths))}
+    user "rename" start-paths end-paths))
+
+(defn trash-notification
+  [user start-paths failed?]
+  (amend-notification
+    {:subject (str (completed-text failed?) " moving " (count start-paths) " files(s)/folder(s) to trash")
+     :message (str (completed-text failed?) " moving " (string/join ", " start-paths) " to trash")}
+    user "trash" start-paths [(paths/user-trash-path user)]))
+
+(defn restore-notification
+  [user start-paths end-paths failed?]
+  (amend-notification
+    {:subject (str (completed-text failed?) " restoring " (count start-paths) " files(s)/folder(s) to their original locations")
+     :message (str (completed-text failed?) " restoring " (string/join ", " start-paths) " to " (string/join ", " end-paths))}
+    user "restore" start-paths end-paths))
+
+(defn empty-trash-notification
+  [user failed?]
+  {:type "data"
+   :user user
+   :subject (str (completed-text failed?) " emptying trash")
+   :message (str (completed-text failed?) " emptying trash")
+   :payload {:action "empty_trash"
+             :paths [(paths/user-trash-path user)]}})

--- a/src/data_info/services/trash.clj
+++ b/src/data_info/services/trash.clj
@@ -92,7 +92,7 @@
        (validate-not-homedir user paths)
 
        (let [trash-paths (apply merge (mapv
-                           (fn [path]
+                           (fn [^String path]
                              (if-not (.startsWith path (paths/user-trash-path user))
                                {path (randomized-trash-path user path)}
                                {}))

--- a/src/data_info/util/config.clj
+++ b/src/data_info/util/config.clj
@@ -103,6 +103,11 @@
   [props config-valid configs]
   "data-info.metadata.base-url" "http://metadata:60000")
 
+(cc/defprop-optstr notificationagent-base-url
+  "The base URL to use when connecting to the notification-agent services."
+  [props config-valid configs]
+  "data-info.notificationagent.base-url" "http://notification-agent:60000")
+
 (cc/defprop-optstr tree-urls-base-url
   "The base URL of the tree-urls service"
   [props config-valid configs]


### PR DESCRIPTION
Sends notifications at the end of moves, renames, move to trash, restore from trash, and emptying trash.