### PR TITLE
Improve listing performance using clj-irods

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [net.sf.opencsv/opencsv "2.3"]
                  [de.ubercode.clostache/clostache "1.4.0" :exclusions [org.clojure/core.incubator]]
                  [slingshot "0.12.2"]
-                 [org.cyverse/clj-irods "0.1.0-SNAPSHOT"]
+                 [org.cyverse/clj-irods "0.1.0"]
                  [org.cyverse/clj-icat-direct "2.8.8"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]

--- a/project.clj
+++ b/project.clj
@@ -31,10 +31,11 @@
                  [net.sf.opencsv/opencsv "2.3"]
                  [de.ubercode.clostache/clostache "1.4.0" :exclusions [org.clojure/core.incubator]]
                  [slingshot "0.12.2"]
-                 [org.cyverse/clj-icat-direct "2.8.6"
+                 [org.cyverse/clj-irods "0.1.0-SNAPSHOT"]
+                 [org.cyverse/clj-icat-direct "2.8.8-SNAPSHOT"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clj-jargon "2.8.10"
+                 [org.cyverse/clj-jargon "2.8.11-SNAPSHOT"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [org.cyverse/clojure-commons "2.8.3"]

--- a/project.clj
+++ b/project.clj
@@ -32,10 +32,10 @@
                  [de.ubercode.clostache/clostache "1.4.0" :exclusions [org.clojure/core.incubator]]
                  [slingshot "0.12.2"]
                  [org.cyverse/clj-irods "0.1.0-SNAPSHOT"]
-                 [org.cyverse/clj-icat-direct "2.8.8-SNAPSHOT"
+                 [org.cyverse/clj-icat-direct "2.8.8"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clj-jargon "2.8.11-SNAPSHOT"
+                 [org.cyverse/clj-jargon "2.8.11"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [org.cyverse/clojure-commons "2.8.3"]

--- a/src/data_info/services/entry.clj
+++ b/src/data_info/services/entry.clj
@@ -206,11 +206,11 @@
         date-created (rods/date-created irods user zone path)
         mod-date     (rods/date-modified irods user zone path)
         name         (fs/base-name path)]
-      (clean-return (:jargon irods) ;; ensure that the with-jargon is closed out
-        (merge (fmt-entry @id @date-created @mod-date bad? nil path name @perm 0)
-               (page->map (partial is-bad? bad-indicator) @page)
-               {:total    @total
-                :totalBad 0}))))
+    (clean-return (:jargon irods) ;; ensure that the with-jargon is closed out
+      (merge (fmt-entry @id @date-created @mod-date bad? nil path name @perm 0)
+             (page->map (partial is-bad? bad-indicator) @page)
+             {:total    @total
+              :totalBad 0}))))
 
 
 (defn- folder-entry


### PR DESCRIPTION
Pretty straightforward, I think. As you might expect, depends a decent bit on https://github.com/cyverse-de/clj-irods/pull/1, which depends on https://github.com/cyverse-de/clj-jargon/pull/10 and https://github.com/cyverse-de/clj-icat-direct/pull/7

But, this improves performance a pretty significant amount, especially for smaller folders, given that it means listings don't need to set up an irods connection at all. Should be some benefits for file viewing too.