### PR TITLE
Speed up do-simple-uuid-for-path with clj-irods

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,11 +31,11 @@
                  [net.sf.opencsv/opencsv "2.3"]
                  [de.ubercode.clostache/clostache "1.4.0" :exclusions [org.clojure/core.incubator]]
                  [slingshot "0.12.2"]
-                 [org.cyverse/clj-irods "0.1.1-SNAPSHOT"]
-                 [org.cyverse/clj-icat-direct "2.8.9-SNAPSHOT"
+                 [org.cyverse/clj-irods "0.1.1"]
+                 [org.cyverse/clj-icat-direct "2.8.9"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clj-jargon "2.8.12-SNAPSHOT"
+                 [org.cyverse/clj-jargon "2.8.12"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [org.cyverse/clojure-commons "2.8.3"]

--- a/project.clj
+++ b/project.clj
@@ -31,11 +31,11 @@
                  [net.sf.opencsv/opencsv "2.3"]
                  [de.ubercode.clostache/clostache "1.4.0" :exclusions [org.clojure/core.incubator]]
                  [slingshot "0.12.2"]
-                 [org.cyverse/clj-irods "0.1.0"]
-                 [org.cyverse/clj-icat-direct "2.8.8"
+                 [org.cyverse/clj-irods "0.1.1-SNAPSHOT"]
+                 [org.cyverse/clj-icat-direct "2.8.9-SNAPSHOT"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clj-jargon "2.8.11"
+                 [org.cyverse/clj-jargon "2.8.12-SNAPSHOT"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [org.cyverse/clojure-commons "2.8.3"]


### PR DESCRIPTION
Uses the conjunction of https://github.com/cyverse-de/clj-irods/pull/2 https://github.com/cyverse-de/clj-icat-direct/pull/8 and https://github.com/cyverse-de/clj-jargon/pull/11 to dramatically speed up the "uuid for path" endpoint, which is used by... a lot, because right now anything in data-info that takes only UUIDs where terrain takes a path, terrain has to get the UUID from this endpoint first.

In my testing, this takes the response time from sometimes as long as a second, down to what seems to usually be 70-80ms.