### PR TITLE
Optimize save/overwrite endpoints with clj-irods and some other tweaks

### DIFF
--- a/src/data_info/routes/data.clj
+++ b/src/data_info/routes/data.clj
@@ -14,6 +14,7 @@
             [data-info.services.page-tabular :as page-tabular]
             [data-info.services.uuids :as uuids]
             [data-info.util.config :as cfg]
+            [schema.core :as s]
             [clojure-commons.error-codes :as ce]
             [data-info.util.service :as svc]))
 
@@ -56,7 +57,7 @@
 
     (POST "/" [:as {uri :uri}]
       :query [params FileUploadQueryParams]
-      :multipart-params [file :- String]
+      :multipart-params [file :- s/Any]
       :middleware [write/wrap-multipart-create]
       :return FileStat
       :summary "Upload a file"
@@ -149,7 +150,7 @@ with characters in a runtime-configurable parameter. Currently, this parameter l
 
       (PUT "/" [:as {uri :uri}]
         :query [params StandardUserQueryParams]
-        :multipart-params [file :- String]
+        :multipart-params [file :- s/Any]
         :middleware [write/wrap-multipart-overwrite]
         :return FileStat
         :summary "Overwrite Contents"

--- a/src/data_info/services/write.clj
+++ b/src/data_info/services/write.clj
@@ -3,9 +3,13 @@
             [clojure-commons.error-codes :as ce]
             [clj-jargon.item-info :as info]
             [clj-jargon.item-ops :as ops]
+            [clj-irods.core :as rods]
+            [clj-irods.validate :refer [validate]]
             [ring.middleware.multipart-params :as multipart]
+            [otel.otel :as otel]
             [data-info.services.stat :as stat]
             [data-info.services.uuids :as uuids]
+            [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]
             [data-info.util.validators :as validators]))
 
@@ -13,39 +17,43 @@
   "Save an istream to a destination. Relies on upstream functions to validate."
   [cm istream user dest-path set-owner?]
   (ops/copy-stream cm istream user dest-path :set-owner? set-owner?)
-  dest-path)
+  (stat/path-stat cm user dest-path))
 
 (defn- create-at-path
   "Create a new file at dest-path from istream.
 
    Error if the path exists or if the destination directory does not exist or is not writeable."
-  [cm istream user dest-path]
-  (let [dest-dir (ft/dirname dest-path)]
-    (validators/user-exists cm user)
-    (validators/path-not-exists cm dest-path)
-    (validators/path-exists cm dest-dir)
-    (validators/path-writeable cm user dest-dir)
-    (save-file-contents cm istream user dest-path true)))
+  [irods istream user dest-path]
+  (otel/with-span [s ["create-at-path"]]
+    (let [dest-dir (ft/dirname dest-path)]
+      (validate irods
+                [:path-not-exists dest-path user (cfg/irods-zone)]
+                [:path-exists dest-dir user (cfg/irods-zone)]
+                [:path-writeable dest-dir user (cfg/irods-zone)])
+      (save-file-contents @(:jargon irods) istream user dest-path true))))
 
 (defn- overwrite-path
   "Save new contents for the file at dest-path from istream.
 
    Error if there is no file at that path or the user lacks write permissions thereupon."
-  [cm istream user dest-path]
-  (validators/user-exists cm user)
-  (validators/path-exists cm dest-path)
-  (validators/path-is-file cm dest-path)
-  (validators/path-writeable cm user dest-path)
-  (save-file-contents cm istream user dest-path false))
+  [irods istream user dest-path]
+  (otel/with-span [s ["overwrite-path"]]
+    (validate irods
+              [:path-exists dest-path user (cfg/irods-zone)]
+              [:path-is-file dest-path user (cfg/irods-zone)]
+              [:path-readable dest-path user (cfg/irods-zone)])
+    (save-file-contents @(:jargon irods) istream user dest-path false)))
 
 (defn- multipart-create-handler
   "When partially applied, creates a storage handler for
    ring.middleware.multipart-params/multipart-params-request which stores the file in iRODS."
   [user dest-dir {istream :stream filename :filename}]
-  (validators/good-pathname filename)
-  (irods/with-jargon-exceptions :client-user user [cm]
-    (let [dest-path (ft/path-join dest-dir filename)]
-      (create-at-path cm istream user dest-path))))
+  (otel/with-span [s ["multipart-create-handler"]]
+    (validators/good-pathname filename)
+    (irods/with-irods-exceptions {:jargon-opts {:client-user user}} irods
+      (validate irods [:user-exists user (cfg/irods-zone)])
+      (let [dest-path (ft/path-join dest-dir filename)]
+        (create-at-path irods istream user dest-path)))))
 
 (defn wrap-multipart-create
   "Middleware which saves a new file from a multipart request."
@@ -56,19 +64,22 @@
 (defn- multipart-overwrite-handler
   "When partially applied, creates a storage handler for
    ring.middleware.multipart-params/multipart-params-request which overwrites the file in iRODS."
-  [user data-id {istream :stream}]
-  (irods/with-jargon-exceptions :client-user user [cm]
-    (let [path (ft/rm-last-slash (uuids/path-for-uuid cm user data-id))]
-      (overwrite-path cm istream user path))))
+  [user path-or-uuid uuid? {istream :stream}]
+  (otel/with-span [s ["multipart-overwrite-handler"]]
+    (irods/with-irods-exceptions {:jargon-opts {:client-user user}} irods
+      (validate irods [:user-exists user (cfg/irods-zone)])
+      (let [path (ft/rm-last-slash (if uuid?
+                                     @(rods/uuid->path irods path-or-uuid)
+                                     path-or-uuid))]
+        (overwrite-path irods istream user path)))))
 
 (defn wrap-multipart-overwrite
   "Middleware which overwrites a file's contents from a multipart request."
   [handler]
   (fn [{{:keys [user data-id]} :params :as request}]
-    (handler (multipart/multipart-params-request request {:store (partial multipart-overwrite-handler user data-id)}))))
+    (handler (multipart/multipart-params-request request {:store (partial multipart-overwrite-handler user data-id true)}))))
 
 (defn do-upload
   "Returns a path stat after a file has been uploaded. Intended to only be used with wrap-multipart-* middlewares."
-  [{:keys [user]} file]
-  (irods/with-jargon-exceptions [cm]
-    {:file (stat/path-stat cm user file)}))
+  [_ file]
+  {:file file})

--- a/src/data_info/services/write.clj
+++ b/src/data_info/services/write.clj
@@ -17,6 +17,9 @@
   "Save an istream to a destination. Relies on upstream functions to validate."
   [cm istream user dest-path set-owner?]
   (ops/copy-stream cm istream user dest-path :set-owner? set-owner?)
+  ;; we don't want to convert the below to clj-irods without cache
+  ;; invalidation, since prior validations would have inaccurate info for this
+  ;; new content
   (stat/path-stat cm user dest-path))
 
 (defn- create-at-path


### PR DESCRIPTION
Right now, could still use some improvement, but it does:

a.) Reduce to one clj-jargon connection by way of me figuring out how multipart stuff works better than I did a few years ago when I wrote this code
b.) change validations to use clj-irods
c.) instrument with opentelemetry

More to come, possibly.