### PR TITLE
Fix roots endpoint: invalidate cached values in make-root when changes are made

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [net.sf.opencsv/opencsv "2.3"]
                  [de.ubercode.clostache/clostache "1.4.0" :exclusions [org.clojure/core.incubator]]
                  [slingshot "0.12.2"]
-                 [org.cyverse/clj-irods "0.1.2"]
+                 [org.cyverse/clj-irods "0.1.3-SNAPSHOT"]
                  [org.cyverse/clj-icat-direct "2.8.10"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]

--- a/src/data_info/services/root.clj
+++ b/src/data_info/services/root.clj
@@ -35,11 +35,13 @@
   [irods user root-path]
   (when (= @(rods/object-type irods user (cfg/irods-zone) root-path) :none)
     (log/info "[make-root] Creating" root-path "for" user)
-    (ops/mkdirs @(:jargon irods) root-path))
+    (ops/mkdirs @(:jargon irods) root-path)
+    (rods/invalidate irods root-path))
 
   (when-not (= @(rods/permission irods user (cfg/irods-zone) root-path) :own)
     (log/info "[make-root] Setting own permissions on" root-path "for" user)
-    (set-permission @(:jargon irods) user root-path :own))
+    (set-permission @(:jargon irods) user root-path :own)
+    (rods/invalidate irods root-path))
 
   (get-root irods user root-path))
 


### PR DESCRIPTION
Uses the changes in cyverse-de/clj-irods#5 to ensure that when `make-root` needs to create a path or set ownership on it (the trash path, incidentally), it invalidates cached results for the path afterwards so they're re-fetched.