### PR TITLE
CORE-1178: Add a readme flag to listings

### DIFF
--- a/src/data_info/services/entry.clj
+++ b/src/data_info/services/entry.clj
@@ -185,22 +185,22 @@
 
 
 (defn- file-exists-under-path
-  [irods user zone path filename bad-indicator]
+  [irods user zone path bad-indicator filename]
   (when (= @(rods/object-type irods user zone (file/path-join path filename)) :file)
     (fmt-entry irods user zone (file/path-join path filename) bad-indicator)))
 
 (defn- has-readme?
   [irods user zone path bad-indicator & maybe-listing]
-  (let [check-file (partial file-exists-under-path irods user zone path)]
+  (let [check-file (partial file-exists-under-path irods user zone path bad-indicator)]
     (delay
       (when maybe-listing (force maybe-listing))
       (or
-        (check-file "README.md" bad-indicator)
-        (check-file "README.txt" bad-indicator)
-        (check-file "README" bad-indicator)
-        (check-file "readme.md" bad-indicator)
-        (check-file "readme.txt" bad-indicator)
-        (check-file "readme" bad-indicator)
+        (check-file "README.md")
+        (check-file "README.txt")
+        (check-file "README")
+        (check-file "readme.md")
+        (check-file "readme.txt")
+        (check-file "readme")
         false))))
 
 

--- a/src/data_info/services/entry.clj
+++ b/src/data_info/services/entry.clj
@@ -184,23 +184,23 @@
      :folders (mapv xformer collections)}))
 
 
-(defn- file-exists-under-path
+(defn- find-file-under-path
   [irods user zone path bad-indicator filename]
   (when (= @(rods/object-type irods user zone (file/path-join path filename)) :file)
     (fmt-entry irods user zone (file/path-join path filename) bad-indicator)))
 
-(defn- has-readme?
+(defn- readme-info
   [irods user zone path bad-indicator & maybe-listing]
-  (let [check-file (partial file-exists-under-path irods user zone path bad-indicator)]
+  (let [find-readme (partial find-file-under-path irods user zone path bad-indicator)]
     (delay
       (when maybe-listing (force maybe-listing))
       (or
-        (check-file "README.md")
-        (check-file "README.txt")
-        (check-file "README")
-        (check-file "readme.md")
-        (check-file "readme.txt")
-        (check-file "readme")
+        (find-readme "README.md")
+        (find-readme "README.txt")
+        (find-readme "README")
+        (find-readme "readme.md")
+        (find-readme "readme.txt")
+        (find-readme "readme")
         false))))
 
 
@@ -222,7 +222,7 @@
         date-created (rods/date-created irods user zone path)
         mod-date     (rods/date-modified irods user zone path)
         name         (fs/base-name path)
-        readme       (has-readme? irods user zone path bad-indicator page)]
+        readme       (readme-info irods user zone path bad-indicator page)]
     (clean-return (:jargon irods) ;; ensure that the with-jargon is closed out
       (merge (fmt-entry @id @date-created @mod-date bad? nil path name @perm 0)
              (page->map (partial is-bad? bad-indicator) @page)


### PR DESCRIPTION
This indicates the presence of a readme by returning a filename, or absence by returning false.

Pretty straightforward, really. We ensure that the listing itself has come back already, because then if the readme files being checked appear within the page, it doesn't need to hit IRODS or the ICAT to confirm they exist.