### PR TITLE
Set info-type on upload

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,7 @@
                  [org.cyverse/clj-icat-direct "2.9.1"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clj-jargon "2.8.12"
+                 [org.cyverse/clj-jargon "2.8.13-SNAPSHOT"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [org.cyverse/clojure-commons "2.8.3"]

--- a/src/data_info/services/write.clj
+++ b/src/data_info/services/write.clj
@@ -48,11 +48,11 @@
 (defn- set-info-type
   [cm path info-type]
   (otel/with-span [s ["set-info-type"]]
-    (let [existing (meta/get-attribute cm path (cfg/type-detect-type-attribute))]
+    (let [existing (meta/get-attribute cm path (cfg/type-detect-type-attribute) :known-type :file)]
       (if (seq existing)
         (:value (first existing) "")
         (do (log/info "adding type" info-type " to file " path)
-            (meta/add-metadata cm path (cfg/type-detect-type-attribute) info-type "ipc-data-info-detected")
+            (meta/add-metadata cm path (cfg/type-detect-type-attribute) info-type "ipc-data-info-detected" :known-type :file)
             info-type)))))
 
 (defn- save-file-contents

--- a/src/data_info/util/config.clj
+++ b/src/data_info/util/config.clj
@@ -223,6 +223,11 @@
   [props config-valid configs]
   "data-info.type-detect.type-attribute" "ipc-filetype")
 
+(cc/defprop-optstr type-detect-read-amount
+  "The number of bytes to read from a file to pass to the info-type detection process."
+  [props config-valid configs]
+  "data-info.type-detect.read-amount" 1024)
+
 ; End of type detection configuration
 
 


### PR DESCRIPTION
Seeking input on this. In my rudimentary testing, this adds about 250ms to the endpoint response time due to the call to `add-metadata`. Actually detecting the info-type, from the upload's `InputStream`, is done in a future and so doesn't add to the time meaningfully. The `decorate-stat` still takes about 350ms, plus ~80ms that is moved from the decorate-stat to the new code (the code that fetches existing info-types). The post-upload code (the stat/decorate-stat/this) could probably be faster for read-only operations by using clj-irods (now that invalidation is a thing), but this 250ms or so would be unchanged. Basically, I'm wondering if it seems worth splitting this into an async task. The file upload itself overshadows this significantly, and will more the larger the file.