### PR TITLE
CORE-1249: use clj-irods to obtain information for the stat-gatherer endpoint.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,11 +32,11 @@
                  [de.ubercode.clostache/clostache "1.4.0" :exclusions [org.clojure/core.incubator]]
                  [slingshot "0.12.2"]
                  [org.cyverse/otel "0.2.1"]
-                 [org.cyverse/clj-irods "0.2.1"]
-                 [org.cyverse/clj-icat-direct "2.9.1"
+                 [org.cyverse/clj-irods "0.2.2-SNAPSHOT"]
+                 [org.cyverse/clj-icat-direct "2.9.2"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clj-jargon "2.8.13-SNAPSHOT"
+                 [org.cyverse/clj-jargon "2.8.13"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [org.cyverse/clojure-commons "2.8.3"]

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [metosin/compojure-api "1.1.13"]
                  [org.cyverse/otel "0.2.3"]
                  [org.cyverse/clj-irods "0.2.2-SNAPSHOT"]
-                 [org.cyverse/clj-icat-direct "2.9.2"
+                 [org.cyverse/clj-icat-direct "2.9.3-SNAPSHOT"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [org.cyverse/clj-jargon "2.8.13"

--- a/project.clj
+++ b/project.clj
@@ -30,11 +30,11 @@
                  [javax.servlet/servlet-api "2.5"]
                  [metosin/compojure-api "1.1.13"]
                  [org.cyverse/otel "0.2.3"]
-                 [org.cyverse/clj-irods "0.2.2-SNAPSHOT"]
-                 [org.cyverse/clj-icat-direct "2.9.3-SNAPSHOT"
+                 [org.cyverse/clj-irods "0.2.2"]
+                 [org.cyverse/clj-icat-direct "2.9.3"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clj-jargon "2.8.13"
+                 [org.cyverse/clj-jargon "2.8.14"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [org.cyverse/clojure-commons "3.0.6"]

--- a/project.clj
+++ b/project.clj
@@ -14,24 +14,22 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "data-info-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/data.codec "0.1.0"]
-                 [org.clojure/tools.nrepl "0.2.10"]
-                 [cheshire "5.6.3"
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [cheshire "5.10.0"
                    :exclusions [[com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]
                                 [com.fasterxml.jackson.dataformat/jackson-dataformat-smile]
                                 [com.fasterxml.jackson.core/jackson-annotations]
                                 [com.fasterxml.jackson.core/jackson-databind]
                                 [com.fasterxml.jackson.core/jackson-core]]]
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
-                 [dire "0.5.3"]
+                 [dire "0.5.4"]
                  [me.raynes/fs "1.4.6"]
-                 [metosin/compojure-api "1.1.8"]
-                 [org.apache.tika/tika-core "1.16"]
+                 [org.apache.tika/tika-core "1.26"]
                  [net.sf.opencsv/opencsv "2.3"]
                  [de.ubercode.clostache/clostache "1.4.0" :exclusions [org.clojure/core.incubator]]
-                 [slingshot "0.12.2"]
-                 [org.cyverse/otel "0.2.1"]
+                 [javax.servlet/servlet-api "2.5"]
+                 [metosin/compojure-api "1.1.13"]
+                 [org.cyverse/otel "0.2.3"]
                  [org.cyverse/clj-irods "0.2.2-SNAPSHOT"]
                  [org.cyverse/clj-icat-direct "2.9.2"
                    :exclusions [[org.slf4j/slf4j-log4j12]
@@ -39,19 +37,20 @@
                  [org.cyverse/clj-jargon "2.8.13"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clojure-commons "2.8.3"]
+                 [org.cyverse/clojure-commons "3.0.6"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.27"]
+                 [org.cyverse/common-swagger-api "3.1.0"]
                  [org.cyverse/heuristomancer "2.8.6"]
-                 [org.cyverse/kameleon "3.0.4"]
-                 [org.cyverse/metadata-client "3.0.0"]
+                 [org.cyverse/kameleon "3.0.5"]
+                 [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/async-tasks-client "0.0.3"]
-                 [org.cyverse/metadata-files "1.0.2"]
+                 [org.cyverse/metadata-files "1.0.3"]
                  [org.cyverse/oai-ore "1.0.3"]
-                 [org.cyverse/service-logging "2.8.0"]
+                 [org.cyverse/service-logging "2.8.2"]
                  [org.cyverse/event-messages "0.0.1"]
-                 [com.novemberain/langohr "3.5.1"]]
+                 [com.novemberain/langohr "3.5.1"]
+                 [slingshot "0.12.2"]]
   :eastwood {:exclude-namespaces [data-info.routes.schemas.tickets
                                   data-info.routes.schemas.stats
                                   data-info.routes.schemas.sharing
@@ -59,9 +58,8 @@
                                   :test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
   :plugins [[test2junit "1.1.3"]
-            [jonase/eastwood "0.3.4"]]
-  :profiles {:dev     {:dependencies   [[ring "1.5.0"]] ;; required for lein-ring with compojure-api 1.1.8+
-                       :plugins        [[lein-ring "0.9.7"]]
+            [jonase/eastwood "0.4.0"]]
+  :profiles {:dev     {:plugins        [[lein-ring "0.12.5"]]
                        :resource-paths ["conf/test"]}
              :uberjar {:aot :all}}
   :main ^:skip-aot data-info.core

--- a/src/data_info/core.clj
+++ b/src/data_info/core.clj
@@ -6,16 +6,10 @@
             [data-info.util.config :as config]
             [data-info.amqp :as amqp]
             [data-info.events :as events]
-            [clojure.tools.nrepl.server :as nrepl]
             [me.raynes.fs :as fs]
             [common-cli.core :as ccli]
             [service-logging.thread-context :as tc]
             [data-info.services.icat :as icat]))
-
-
-(defn- start-nrepl
-  []
-  (nrepl/start-server :port 7888))
 
 
 (defn- iplant-conf-dir-file
@@ -66,8 +60,7 @@
 (defn lein-ring-init
   []
   (load-configuration-from-file)
-  (icat/configure-icat)
-  (start-nrepl))
+  (icat/configure-icat))
 
 
 (defn repl-init

--- a/src/data_info/services/directory.clj
+++ b/src/data_info/services/directory.clj
@@ -58,7 +58,7 @@
               [:path-exists path user zone]
               [:path-readable path user zone]
               [:path-is-dir path user zone])
-    (-> (stat/new-path-stat irods user path :filter-include [:id :label :path :date-created :date-modified :permission])
+    (-> (stat/path-stat irods user path :filter-include [:id :label :path :date-created :date-modified :permission])
         (assoc :folders (map (partial fmt-folder user)
                              (icat/list-folders-in-folder user (cfg/irods-zone) path))))))
 

--- a/src/data_info/services/home.clj
+++ b/src/data_info/services/home.clj
@@ -16,7 +16,7 @@
       (validate irods [:user-exists user zone])
       (when-not (exists? @(:jargon irods) user-home)
         (mkdirs @(:jargon irods) user-home))
-      (stat/new-path-stat irods user user-home :filter-include [:id :label :path :date-created :date-modified :permission]))))
+      (stat/path-stat irods user user-home :filter-include [:id :label :path :date-created :date-modified :permission]))))
 
 (defn do-homedir
   [{user :user}]

--- a/src/data_info/services/home.clj
+++ b/src/data_info/services/home.clj
@@ -1,25 +1,26 @@
 (ns data-info.services.home
   (:require [dire.core :refer [with-pre-hook! with-post-hook!]]
+            [clj-irods.validate :refer [validate]]
             [clj-jargon.item-info :refer [exists?]]
             [clj-jargon.item-ops :refer [mkdirs]]
             [data-info.services.stat :as stat]
+            [data-info.util.config :as cfg]
             [data-info.util.logging :as log]
             [data-info.util.irods :as irods]
-            [data-info.util.validators :as validators]
             [data-info.util.paths :as path]))
 
 (defn- user-home-path
-  [user]
+  [user zone]
   (let [user-home (path/user-home-dir user)]
-    (irods/with-jargon-exceptions [cm]
-      (validators/user-exists cm user)
-      (when-not (exists? cm user-home)
-        (mkdirs cm user-home))
-      (stat/path-stat cm user user-home :filter-include [:id :label :path :date-created :date-modified :permission]))))
+    (irods/with-irods-exceptions {} irods
+      (validate irods [:user-exists user zone])
+      (when-not (exists? @(:jargon irods) user-home)
+        (mkdirs @(:jargon irods) user-home))
+      (stat/new-path-stat irods user user-home :filter-include [:id :label :path :date-created :date-modified :permission]))))
 
 (defn do-homedir
   [{user :user}]
-  (user-home-path user))
+  (user-home-path user (cfg/irods-zone)))
 
 (with-pre-hook! #'do-homedir
   (fn [params]

--- a/src/data_info/services/home.clj
+++ b/src/data_info/services/home.clj
@@ -1,5 +1,6 @@
 (ns data-info.services.home
   (:require [dire.core :refer [with-pre-hook! with-post-hook!]]
+            [clj-irods.core :as rods]
             [clj-irods.validate :refer [validate]]
             [clj-jargon.item-info :refer [exists?]]
             [clj-jargon.item-ops :refer [mkdirs]]
@@ -15,7 +16,8 @@
     (irods/with-irods-exceptions {} irods
       (validate irods [:user-exists user zone])
       (when (= @(rods/object-type irods user zone user-home) :none)
-        (mkdirs @(:jargon irods) user-home))
+        (mkdirs @(:jargon irods) user-home)
+        (rods/invalidate irods user-home))
       (stat/path-stat irods user user-home :filter-include [:id :label :path :date-created :date-modified :permission]))))
 
 (defn do-homedir

--- a/src/data_info/services/home.clj
+++ b/src/data_info/services/home.clj
@@ -14,7 +14,7 @@
   (let [user-home (path/user-home-dir user)]
     (irods/with-irods-exceptions {} irods
       (validate irods [:user-exists user zone])
-      (when-not (exists? @(:jargon irods) user-home)
+      (when (= @(rods/object-type irods user zone user-home) :none)
         (mkdirs @(:jargon irods) user-home))
       (stat/path-stat irods user user-home :filter-include [:id :label :path :date-created :date-modified :permission]))))
 

--- a/src/data_info/services/path_lists.clj
+++ b/src/data_info/services/path_lists.clj
@@ -8,7 +8,8 @@
             [clj-jargon.item-info :as item-info]
             [clj-jargon.permissions :as perms]
             [data-info.services.filetypes :as filetypes]
-            [data-info.services.stat :as stat]
+            [data-info.services.stat.common :refer [process-filters]]
+            [data-info.services.stat.jargon :as jargon-stat]
             [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]
             [data-info.util.validators :as validators]))
@@ -85,7 +86,7 @@
 
 (defn- get-top-level-file-stats
   [cm user path]
-  (stat/path-stat cm user path :filter-include [:path :infoType :label :permission :type]))
+  (jargon-stat/path-stat cm user path :filter-include [:path :infoType :label :permission :type]))
 
 (defn- paths->path-list
   "Filters the given paths and returns a string of these paths appended to an HT Path List header.
@@ -148,4 +149,4 @@
                                                 paths)
           path-list-file-stat (with-in-str path-list-contents (copy-stream cm *in* user dest))]
       (filetypes/add-type-to-validated-path cm dest path-list-info-type)
-      {:file (stat/decorate-stat cm user path-list-file-stat (stat/process-filters nil nil))})))
+      {:file (jargon-stat/decorate-stat cm user path-list-file-stat (process-filters nil nil))})))

--- a/src/data_info/services/stat.clj
+++ b/src/data_info/services/stat.clj
@@ -1,59 +1,18 @@
 (ns data-info.services.stat
-  (:require [clojure.string :as string]
-            [clojure.set :as cset]
-            [clojure.tools.logging :as log]
-            [dire.core :refer [with-pre-hook! with-post-hook!]]
-            [slingshot.slingshot :refer [throw+]]
+  (:require [dire.core :refer [with-pre-hook! with-post-hook!]]
             [otel.otel :as otel]
-            [clj-icat-direct.icat :as icat]
             [clj-irods.core :as rods]
             [clj-irods.validate :refer [validate]]
-            [clj-jargon.by-uuid :as uuid]
-            [clj-jargon.item-info :as info]
-            [clj-jargon.metadata :as meta]
-            [clj-jargon.permissions :as perm]
             [clojure-commons.file-utils :as ft]
-            [common-swagger-api.schema.stats :refer [AvailableStatFields]]
+            [data-info.services.stat.common
+             :refer [is-dir? owns? needs-key? needs-any-key? assoc-if-selected merge-label process-filters]]
             [data-info.util.config :as cfg]
             [data-info.util.logging :as dul]
             [data-info.util.irods :as irods]
-            [data-info.util.paths :as paths]
-            [data-info.services.uuids :as uuids]
             [data-info.util.validators :as validators])
   (:import [clojure.lang IPersistentMap]))
 
-
-(defn- is-dir?
-  [stat-map]
-  (= (:type stat-map) :dir))
-
-(defn- owns?
-  [stat-map]
-  (= (:permission stat-map) :own))
-
-(defn- needs-key?
-  [requested-keys needed-key?]
-  (or (contains? requested-keys needed-key?)
-    (case needed-key?
-      ; :permission is needed by anything which uses `owns?`
-      :permission (contains? requested-keys :share-count)
-      ; :type is needed by anything which uses `is-dir?`
-      :type       (not (empty? (cset/intersection #{:infoType :content-type :file-count :dir-count} requested-keys)))
-      false)))
-
-(defn- needs-any-key?
-  [included-keys & needed-keys]
-  (some #(needs-key? included-keys %) needed-keys))
-
-(defmacro assoc-if-selected
-  "Adds keys and values to a map. If the key is in the set of requested keys then the value
-   is associated with the map. Otherwise, nil is associated with the map and the expression
-   used to calculate the value is not executed."
-  [m requested-keys & kvs]
-  (let [format-kv (fn [[k v]] [k `(when (needs-key? ~requested-keys ~k) ~v)])]
-    (concat `(assoc ~m) (mapcat format-kv (partition 2 kvs)))))
-
-(defn- new-get-types
+(defn- get-types
   "Gets the file type associated with the path."
   [irods user zone path & {:keys [validate?] :or {validate? true}}]
   (when validate?
@@ -63,164 +22,60 @@
               [:path-readable path user zone]))
   @(rods/info-type irods user zone path))
 
-(defn- get-types
-  "Gets the file type associated with path."
-  [cm user path & {:keys [validate?] :or {validate? true}}]
-  (when validate?
-    (validators/path-exists cm path)
-    (validators/user-exists cm user)
-    (validators/path-readable cm user path))
-  (let [path-types (meta/get-attribute cm path (cfg/type-detect-type-attribute))]
-    (log/info "Retrieved types" path-types "from" path "for" (str user "."))
-    (or (:value (first path-types) ""))))
-
-(defn- new-count-shares
+(defn- count-shares
   [irods user path]
   (let [user-filter (set (conj (cfg/perms-filter) user (cfg/irods-user)))]
     (count (remove (comp user-filter :user) @(rods/list-user-permissions irods path)))))
 
-(defn- count-shares
-  [cm user path]
-  (let [filter-users (set (conj (cfg/perms-filter) user (cfg/irods-user)))
-        other-perm?  (fn [perm] (not (contains? filter-users (:user perm))))]
-    (count (filterv other-perm? (perm/list-user-perms cm path)))))
-
-(defn- new-merge-counts
+(defn- merge-counts
   [stat-map irods user zone path included-keys]
   (if (and (needs-any-key? included-keys :file-count :dir-count) (is-dir? stat-map))
-    (otel/with-span [s ["new-merge-counts"]]
+    (otel/with-span [s ["merge-counts"]]
       (assoc-if-selected stat-map included-keys
         :file-count @(rods/number-of-files-in-folder irods user zone path)
         :dir-count  @(rods/number-of-folders-in-folder irods user zone path)))
     stat-map))
 
-(defn- merge-counts
-  [stat-map cm user path included-keys]
-  (if (and (needs-any-key? included-keys :file-count :dir-count) (is-dir? stat-map))
-    (otel/with-span [s ["merge-counts"]]
-      (assoc stat-map
-        :file-count (when (needs-key? included-keys :file-count) (icat/number-of-files-in-folder user (cfg/irods-zone) path))
-        :dir-count  (when (needs-key? included-keys :dir-count)  (icat/number-of-folders-in-folder user (cfg/irods-zone) path))))
-    stat-map))
-
-(defn- new-merge-shares
+(defn- merge-shares
   [stat-map irods user path included-keys]
   (if (and (needs-key? included-keys :share-count) (owns? stat-map))
-    (otel/with-span [s ["new-merge-shares"]]
-      (assoc stat-map :share-count (new-count-shares irods user path)))
-    stat-map))
-
-(defn- merge-shares
-  [stat-map cm user path included-keys]
-  (if (and (needs-key? included-keys :share-count) (owns? stat-map))
     (otel/with-span [s ["merge-shares"]]
-      (assoc stat-map :share-count (count-shares cm user path)))
-    stat-map))
-
-(defn- merge-label
-  [stat-map user path included-keys]
-  (if (needs-key? included-keys :label)
-    (assoc stat-map
-           :label (paths/path->label user path))
-    stat-map))
-
-(defn- new-merge-type-info
-  [stat-map irods user zone path included-keys & {:keys [validate?] :or {validate? true}}]
-  (if (and (needs-any-key? included-keys :infoType :content-type) (not (is-dir? stat-map)))
-    (otel/with-span [s ["new-merge-type-info"]]
-      (assoc-if-selected stat-map included-keys
-        :infoType     (new-get-types irods user zone path :validate? validate?)
-        :content-type (irods/detect-media-type @(:jargon irods) path)))
+      (assoc stat-map :share-count (count-shares irods user path)))
     stat-map))
 
 (defn- merge-type-info
-  [stat-map cm user path included-keys & {:keys [validate?] :or {validate? true}}]
+  [stat-map irods user zone path included-keys & {:keys [validate?] :or {validate? true}}]
   (if (and (needs-any-key? included-keys :infoType :content-type) (not (is-dir? stat-map)))
     (otel/with-span [s ["merge-type-info"]]
-      (assoc stat-map
-        :infoType     (when (needs-key? included-keys :infoType) (get-types cm user path :validate? validate?))
-        :content-type (when (needs-key? included-keys :content-type) (irods/detect-media-type cm path))))
+      (assoc-if-selected stat-map included-keys
+        :infoType     (get-types irods user zone path :validate? validate?)
+        :content-type (irods/detect-media-type @(:jargon irods) path)))
     stat-map))
 
-(defn new-decorate-stat
+(defn decorate-stat
   [irods user zone {:keys [path] :as stat} included-keys & {:keys [validate?] :or {validate? true}}]
-  (otel/with-span [s ["new-decorate-stat"]]
+  (otel/with-span [s ["decorate-stat"]]
     (-> stat
         (assoc-if-selected included-keys
           :id         @(rods/uuid irods user zone path)
           :permission @(rods/permission irods user zone path))
         (merge-label user path included-keys)
-        (new-merge-type-info irods user zone path included-keys :validate? validate?)
-        (new-merge-shares irods user path included-keys)
-        (new-merge-counts irods user zone path included-keys)
+        (merge-type-info irods user zone path included-keys :validate? validate?)
+        (merge-shares irods user path included-keys)
+        (merge-counts irods user zone path included-keys)
         (select-keys included-keys))))
 
-(defn ^IPersistentMap decorate-stat
-  [^IPersistentMap cm ^String user ^IPersistentMap stat included-keys & {:keys [validate?] :or {validate? true}}]
-  (otel/with-span [s ["decorate-stat"]]
-    (let [path (:path stat)]
-      (-> stat
-        (assoc :id         (when (needs-key? included-keys :id) (-> (meta/get-attribute cm path uuid/uuid-attr) first :value))
-               :permission (when (needs-key? included-keys :permission) (perm/permission-for cm user path)))
-        (merge-label user path included-keys)
-        (merge-type-info cm user path included-keys :validate? validate?)
-        (merge-shares cm user path included-keys)
-        (merge-counts cm user path included-keys)
-        (select-keys included-keys)))))
-
-(defn- get-filter-set
-  [filter-vec-or-string default]
-  (if (nil? filter-vec-or-string)
-    (set default)
-    (if (string? filter-vec-or-string)
-      (set (map keyword (string/split filter-vec-or-string #",")))
-      (set (map keyword filter-vec-or-string)))))
-
-(defn process-filters
-  "Process an include and an exclude string into just a list of keys to include"
-  [include exclude]
-  (let [all-keys (set AvailableStatFields)
-        includes-set (get-filter-set include all-keys)
-        excludes-set (get-filter-set exclude [])]
-      (cset/intersection all-keys (cset/difference includes-set excludes-set))))
-
-(defn new-path-stat
+(defn path-stat
   [irods user path & {:keys [filter-include filter-exclude validate?]
                       :or   {filter-include nil filter-exclude nil validate? true}}]
-  (otel/with-span [s ["new-path-stat" {:attributes {"path" path}}]]
+  (otel/with-span [s ["path-stat" {:attributes {"path" path}}]]
     (let [path          (ft/rm-last-slash path)
           included-keys (process-filters filter-include filter-exclude)]
       (when validate? (validate irods [:path-exists path user (cfg/irods-zone)]))
       (let [base-stat (if (needs-any-key? included-keys :type :date-created :date-modified :file-size :md5)
                         @(rods/stat irods user (cfg/irods-zone) path)
                         {:path path})]
-        (new-decorate-stat irods user (cfg/irods-zone) base-stat included-keys :validate? validate?)))))
-
-(defn ^IPersistentMap path-stat
-  [^IPersistentMap cm ^String user ^String path & {:keys [filter-include filter-exclude validate?] :or {filter-include nil filter-exclude nil validate? true}}]
-  (otel/with-span [s ["path-stat" {:attributes {"path" path}}]]
-    (let [path (ft/rm-last-slash path)
-          included-keys (process-filters filter-include filter-exclude)]
-      (log/debug "[path-stat] user:" user "path:" path)
-      (when validate? (validators/path-exists cm path))
-      (let [base-stat (if (needs-any-key? included-keys :type :date-created :date-modified :file-size :md5)
-                        (info/stat cm path)
-                        {:path path})]
-        (decorate-stat cm user base-stat included-keys :validate? validate?)))))
-
-(defn ^IPersistentMap uuid-stat
-  [^IPersistentMap cm ^String user uuid & {:keys [filter-include filter-exclude] :or {filter-include nil filter-exclude nil}}]
-  (otel/with-span [s ["uuid-stat"]]
-    (log/debug "[uuid-stat] user:" user "uuid:" uuid)
-    (let [path (uuids/path-for-uuid cm user uuid)]
-      (path-stat cm user path :filter-include filter-include :filter-exclude filter-exclude))))
-
-(defn- get-uuid-paths
-  "Returns a sequence of vectors containing the UUID of a file or folder and its path. UUIDs that can't be
-   found are simply ignored"
-  [cm uuids]
-  (->> (map (juxt (comp keyword str) (partial uuid/get-path cm)) uuids)
-       (remove (comp nil? second))))
+        (decorate-stat irods user (cfg/irods-zone) base-stat included-keys :validate? validate?)))))
 
 (defn- remove-missing-paths
   "Removes non-existent paths from a list of item paths."
@@ -271,9 +126,9 @@
           paths            (filter (set accessible-paths) paths)
           format-stat      (fn [path]
                              ;; TODO: update this to use clj-irods
-                             (new-path-stat irods user path
-                                            :filter-include filter-include
-                                            :filter-exclude filter-exclude))]
+                             (path-stat irods user path
+                                        :filter-include filter-include
+                                        :filter-exclude filter-exclude))]
       {:paths (into {} (map (juxt keyword format-stat) paths))
        :ids   (into {} (map (juxt (comp keyword str first) (comp format-stat second)) uuid-paths))})))
 

--- a/src/data_info/services/stat.clj
+++ b/src/data_info/services/stat.clj
@@ -125,7 +125,6 @@
           uuid-paths       (filter (comp (set accessible-paths) second) uuid-paths)
           paths            (filter (set accessible-paths) paths)
           format-stat      (fn [path]
-                             ;; TODO: update this to use clj-irods
                              (path-stat irods user path
                                         :filter-include filter-include
                                         :filter-exclude filter-exclude))]

--- a/src/data_info/services/stat.clj
+++ b/src/data_info/services/stat.clj
@@ -107,7 +107,8 @@
   [stat-map irods user path included-keys]
   (if (and (needs-key? included-keys :share-count) (owns? stat-map))
     (otel/with-span [s ["new-merge-shares"]]
-      (assoc stat-map :share-count (new-count-shares irods user path)))))
+      (assoc stat-map :share-count (new-count-shares irods user path)))
+    stat-map))
 
 (defn- merge-shares
   [stat-map cm user path included-keys]

--- a/src/data_info/services/stat/common.clj
+++ b/src/data_info/services/stat/common.clj
@@ -1,0 +1,64 @@
+(ns data-info.services.stat.common
+  (:require [clojure.set :as cset]
+            [clojure.string :as string]
+            [common-swagger-api.schema.stats :refer [AvailableStatFields]]
+            [data-info.util.paths :as paths]))
+
+(defn is-dir?
+  "Returns true for any stat map map that contains information about a directory."
+  [stat-map]
+  (= (:type stat-map) :dir))
+
+(defn owns?
+  "Returns true for any stat map containing information about an entity that the user owns."
+  [stat-map]
+  (= (:permission stat-map) :own))
+
+(defn needs-key?
+  "Determins whether or not a key is needed in a stat map. Note: the :permission key is needed by anything that uses
+   `owns?` and the :type key is needed by anything that uses `is-dir?`. In all other cases only requested keys are
+   needed."
+  [requested-keys needed-key?]
+  (or (contains? requested-keys needed-key?)
+      (case needed-key?
+        :permission (contains? requested-keys :share-count)
+        :type       (not (empty? (cset/intersection #{:infoType :content-type :file-count :dir-count} requested-keys)))
+        false)))
+
+(defn needs-any-key?
+  "Determins whether or not any key in a set is needed in a stat map. Note: the :permission key is needed by anything
+   that uses `owns?` and the :type key is needed by anything that uses `is-dir?`. In all other cases only requested
+   keys are needed."
+  [included-keys & needed-keys]
+  (some #(needs-key? included-keys %) needed-keys))
+
+(defmacro assoc-if-selected
+  "Adds keys and values to a map. If the key is in the set of requested keys then the value
+   is associated with the map. Otherwise, nil is associated with the map and the expression
+   used to calculate the value is not executed."
+  [m requested-keys & kvs]
+  (let [format-kv (fn [[k v]] [k `(when (needs-key? ~requested-keys ~k) ~v)])]
+    (concat `(assoc ~m) (mapcat format-kv (partition 2 kvs)))))
+
+(defn merge-label
+  "Merges an entity label into a stat map"
+  [stat-map user path included-keys]
+  (if (needs-key? included-keys :label)
+    (assoc stat-map :label (paths/path->label user path))
+    stat-map))
+
+(defn- get-filter-set
+  [filter-vec-or-string default]
+  (if (nil? filter-vec-or-string)
+    (set default)
+    (if (string? filter-vec-or-string)
+      (set (map keyword (string/split filter-vec-or-string #",")))
+      (set (map keyword filter-vec-or-string)))))
+
+(defn process-filters
+  "Process an include and an exclude string into just a list of keys to include"
+  [include exclude]
+  (let [all-keys (set AvailableStatFields)
+        includes-set (get-filter-set include all-keys)
+        excludes-set (get-filter-set exclude [])]
+    (cset/intersection all-keys (cset/difference includes-set excludes-set))))

--- a/src/data_info/services/stat/common.clj
+++ b/src/data_info/services/stat/common.clj
@@ -15,7 +15,7 @@
   (= (:permission stat-map) :own))
 
 (defn needs-key?
-  "Determins whether or not a key is needed in a stat map. Note: the :permission key is needed by anything that uses
+  "Determines whether or not a key is needed in a stat map. Note: the :permission key is needed by anything that uses
    `owns?` and the :type key is needed by anything that uses `is-dir?`. In all other cases only requested keys are
    needed."
   [requested-keys needed-key?]
@@ -26,7 +26,7 @@
         false)))
 
 (defn needs-any-key?
-  "Determins whether or not any key in a set is needed in a stat map. Note: the :permission key is needed by anything
+  "Determines whether or not any key in a set is needed in a stat map. Note: the :permission key is needed by anything
    that uses `owns?` and the :type key is needed by anything that uses `is-dir?`. In all other cases only requested
    keys are needed."
   [included-keys & needed-keys]

--- a/src/data_info/services/stat/jargon.clj
+++ b/src/data_info/services/stat/jargon.clj
@@ -29,7 +29,7 @@
   [stat-map cm user path included-keys & {:keys [validate?] :or {validate? true}}]
   (if (and (needs-any-key? included-keys :infoType :content-type) (not (is-dir? stat-map)))
     (otel/with-span [s ["merge-type-info"]]
-      (assoc-if-selected included-keys stat-map
+      (assoc-if-selected stat-map included-keys
         :infoType     (get-types cm user path :validate? validate?)
         :content-type (irods/detect-media-type cm path)))
     stat-map))
@@ -51,7 +51,7 @@
   [stat-map cm user path included-keys]
   (if (and (needs-any-key? included-keys :file-count :dir-count) (is-dir? stat-map))
     (otel/with-span [s ["merge-counts"]]
-      (assoc-if-selected included-keys stat-map
+      (assoc-if-selected stat-map included-keys
         :file-count (icat/number-of-files-in-folder user (cfg/irods-zone) path)
         :dir-count  (icat/number-of-folders-in-folder user (cfg/irods-zone) path)))
     stat-map))

--- a/src/data_info/services/stat/jargon.clj
+++ b/src/data_info/services/stat/jargon.clj
@@ -1,0 +1,90 @@
+(ns data-info.services.stat.jargon
+  (:require [clj-icat-direct.icat :as icat]
+            [clj-jargon.by-uuid :as uuid]
+            [clj-jargon.item-info :as info]
+            [clj-jargon.metadata :as meta]
+            [clj-jargon.permissions :as perm]
+            [clojure.tools.logging :as log]
+            [clojure-commons.file-utils :as ft]
+            [data-info.services.stat.common
+             :refer [is-dir? owns? needs-key? needs-any-key? assoc-if-selected merge-label process-filters]]
+            [data-info.services.uuids :as uuids]
+            [data-info.util.config :as cfg]
+            [data-info.util.irods :as irods]
+            [data-info.util.validators :as validators]
+            [otel.otel :as otel]))
+
+(defn- get-types
+  "Gets the file type associated with path."
+  [cm user path & {:keys [validate?] :or {validate? true}}]
+  (when validate?
+    (validators/path-exists cm path)
+    (validators/user-exists cm user)
+    (validators/path-readable cm user path))
+  (let [path-types (meta/get-attribute cm path (cfg/type-detect-type-attribute))]
+    (log/info "Retrieved types" path-types "from" path "for" (str user "."))
+    (or (:value (first path-types) ""))))
+
+(defn- merge-type-info
+  [stat-map cm user path included-keys & {:keys [validate?] :or {validate? true}}]
+  (if (and (needs-any-key? included-keys :infoType :content-type) (not (is-dir? stat-map)))
+    (otel/with-span [s ["merge-type-info"]]
+      (assoc-if-selected included-keys stat-map
+        :infoType     (get-types cm user path :validate? validate?)
+        :content-type (irods/detect-media-type cm path)))
+    stat-map))
+
+(defn- count-shares
+  [cm user path]
+  (let [filter-users (set (conj (cfg/perms-filter) user (cfg/irods-user)))
+        other-perm?  (fn [perm] (not (contains? filter-users (:user perm))))]
+    (count (filterv other-perm? (perm/list-user-perms cm path)))))
+
+(defn- merge-shares
+  [stat-map cm user path included-keys]
+  (if (and (needs-key? included-keys :share-count) (owns? stat-map))
+    (otel/with-span [s ["merge-shares"]]
+      (assoc stat-map :share-count (count-shares cm user path)))
+    stat-map))
+
+(defn- merge-counts
+  [stat-map cm user path included-keys]
+  (if (and (needs-any-key? included-keys :file-count :dir-count) (is-dir? stat-map))
+    (otel/with-span [s ["merge-counts"]]
+      (assoc-if-selected included-keys stat-map
+        :file-count (icat/number-of-files-in-folder user (cfg/irods-zone) path)
+        :dir-count  (icat/number-of-folders-in-folder user (cfg/irods-zone) path)))
+    stat-map))
+
+(defn decorate-stat
+  [cm user {:keys [path] :as stat} included-keys & {:keys [validate?] :or {validate? true}}]
+  (otel/with-span [s ["decorate-stat"]]
+    (-> stat
+        (assoc-if-selected included-keys
+          :id         (-> (meta/get-attribute cm path uuid/uuid-attr) first :value)
+          :permission (perm/permission-for cm user path))
+        (merge-label user path included-keys)
+        (merge-type-info cm user path included-keys :validate? validate?)
+        (merge-shares cm user path included-keys)
+        (merge-counts cm user path included-keys)
+        (select-keys included-keys))))
+
+(defn path-stat
+  [cm user path & {:keys [filter-include filter-exclude validate?]
+                   :or   {filter-include nil filter-exclude nil validate? true}}]
+  (otel/with-span [s ["path-stat" {:attributes {"path" path}}]]
+    (let [path          (ft/rm-last-slash path)
+          included-keys (process-filters filter-include filter-exclude)]
+      (log/debug "[path-stat] user:" user "path:" path)
+      (when validate? (validators/path-exists cm path))
+      (let [base-stat (if (needs-any-key? included-keys :type :date-created :date-modified :file-size :md5)
+                        (info/stat cm path)
+                        {:path path})]
+        (decorate-stat cm user base-stat included-keys :validate? validate?)))))
+
+(defn uuid-stat
+  [cm user uuid & {:keys [filter-include filter-exclude] :or {filter-include nil filter-exclude nil}}]
+  (otel/with-span [s ["uuid-stat"]]
+    (log/debug "[uuid-stat] user:" user "uuid:" uuid)
+    (let [path (uuids/path-for-uuid cm user uuid)]
+      (path-stat cm user path :filter-include filter-include :filter-exclude filter-exclude))))

--- a/src/data_info/services/write.clj
+++ b/src/data_info/services/write.clj
@@ -12,6 +12,7 @@
             [ring.middleware.multipart-params :as multipart]
             [otel.otel :as otel]
             [data-info.services.stat :as stat]
+            [data-info.services.stat.common :refer [process-filters]]
             [data-info.services.uuids :as uuids]
             [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]
@@ -69,9 +70,9 @@
       ;; invalidation, since prior validations would have inaccurate info for this
       ;; new content
       (assoc
-        (stat/decorate-stat @(:jargon irods) user base-stat (stat/process-filters nil [:content-type :infoType]) :validate? false)
-        :infoType     final-info-type
-        :content-type media-type))))
+       (stat/decorate-stat irods user base-stat (process-filters nil [:content-type :infoType]) :validate? false)
+       :infoType     final-info-type
+       :content-type media-type))))
 
 (defn- create-at-path
   "Create a new file at dest-path from istream.

--- a/src/data_info/services/write.clj
+++ b/src/data_info/services/write.clj
@@ -66,11 +66,9 @@
           base-stat (ops/copy-stream @(:jargon irods) @istream-ref user dest-path :set-owner? set-owner?)
           final-info-type (set-info-type @(:jargon irods) dest-path @info-type)]
       (log/info "Detected info-type:" @info-type ", final type:" final-info-type)
-      ;; we don't want to convert the below to clj-irods without cache
-      ;; invalidation, since prior validations would have inaccurate info for this
-      ;; new content
+      (rods/invalidate irods dest-path)
       (assoc
-       (stat/decorate-stat irods user base-stat (process-filters nil [:content-type :infoType]) :validate? false)
+       (stat/decorate-stat irods user (cfg/irods-zone) base-stat (process-filters nil [:content-type :infoType]) :validate? false)
        :infoType     final-info-type
        :content-type media-type))))
 


### PR DESCRIPTION
While I was modifying the stat-gatherer endpoint, I also made the following changes.

- Updated some dependencies.
- Removed the code to set up the nrepl port, which wasn't being used.
- Migrated the `/navigation/path/:zone/:path` endpoint over to clj-irods.
- Migrated the `/navigation/home` endpoint over to clj-irods.
- Moved the old stat formatting code that uses `clj-jargon` over to a new namespace: `data-info.services.stat.jargon`.
- Moved functions shared by both stat formatting namespaces to another new namespace: `data-info.services.stat.common`.
