### PR TITLE
CORE-1430: make it easier to test code changes in the REPL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /native
 /.lein-failures
 /checkouts
+/repl
 .idea/
 *.iml
 .lein-repl-history

--- a/project.clj
+++ b/project.clj
@@ -63,6 +63,7 @@
             [jonase/eastwood "0.4.0"]]
   :profiles {:dev     {:plugins        [[lein-ring "0.12.5"]]
                        :resource-paths ["conf/test"]}
+             :repl    {:source-paths ["repl"]}
              :uberjar {:aot :all}}
   :main ^:skip-aot data-info.core
   :ring {:handler data-info.routes/app


### PR DESCRIPTION
This change is just my usual method for making it easier for me to test code changes with CIDER. I don't think I'm going to modify `data-info` for this issue, but since I was experimenting with possibly updating `data-info` today, I figured I'd submit the PR to get these changes into the main repo.