### PR TITLE
CORE-1462: url-encode paths for anonymous access

### DIFF
--- a/src/data_info/services/sharing.clj
+++ b/src/data_info/services/sharing.clj
@@ -13,7 +13,8 @@
             [data-info.util.paths :as paths]
             [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]
-            [data-info.util.validators :as validators]))
+            [data-info.util.validators :as validators])
+  (:import java.net.URLEncoder))
 
 (defn- shared?
   ([cm share-with fpath]
@@ -160,10 +161,15 @@
     (when-not (nil? matching-key)
       (string/replace-first path matching-key (mappings matching-key)))))
 
+(defn- encode-mapped-anon-path
+  "Take a path that's been appropriately mapped, and URL encode it for use. This function will use %20 for spaces."
+  [mapped-path]
+  (string/join "/" (map #(string/replace (URLEncoder/encode %) #"\+" "%20") (string/split mapped-path #"/"))))
+
 (defn anon-file-url
   [path]
   (let [aurl (url/url (cfg/anon-files-base-url))]
-    (str (-> aurl (assoc :path (apply ft/path-join (:path aurl) [(map-anon-url-path path)]))))))
+    (str (-> aurl (assoc :path (apply ft/path-join (:path aurl) [(encode-mapped-anon-path (map-anon-url-path path))]))))))
 
 (defn- anon-files-urls
   [paths]

--- a/src/data_info/services/sharing.clj
+++ b/src/data_info/services/sharing.clj
@@ -164,7 +164,10 @@
 (defn- encode-mapped-anon-path
   "Take a path that's been appropriately mapped, and URL encode it for use. This function will use %20 for spaces."
   [mapped-path]
-  (string/join "/" (map #(string/replace (URLEncoder/encode %) #"\+" "%20") (string/split mapped-path #"/"))))
+  (as-> mapped-path p
+    (string/split p #"/")
+    (map #(string/replace (URLEncoder/encode %) #"\+" "%20") p)
+    (string/join "/" p)))
 
 (defn anon-file-url
   [path]

--- a/src/data_info/services/sharing.clj
+++ b/src/data_info/services/sharing.clj
@@ -168,8 +168,11 @@
 
 (defn anon-file-url
   [path]
-  (let [aurl (url/url (cfg/anon-files-base-url))]
-    (str (-> aurl (assoc :path (apply ft/path-join (:path aurl) [(encode-mapped-anon-path (map-anon-url-path path))]))))))
+  (let [aurl (url/url (cfg/anon-files-base-url))
+        encoded-path (encode-mapped-anon-path (map-anon-url-path path))]
+    (-> aurl
+        (assoc :path (ft/path-join (:path aurl) encoded-path))
+        str)))
 
 (defn- anon-files-urls
   [paths]


### PR DESCRIPTION
A little bit annoying, but this seems to work with what I've tried it with.

The main annoyance is that java.net.URLEncoder turns spaces into `+` characters. However, since it turns `+` into `%2B`, we can just do a string replace afterwards to get what we want, hacky though it feels. Other than the space-plus thing, it does what we want. Of course, we also don't want to encode the slashes, so I split on those and then re-join the path on them.

It probably won't matter either way, but I've set it up to do this after mapping the path to the appropriate webdav URL. It won't come up with anything we're running, but it could ostensibly matter if we wanted to map something with a space or other needing-url-encoding character to a different path before returning it; this way, the config file uses the unencoded versions, not the encoded ones.