### PR TITLE
IRODS Groups API

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [org.cyverse/clj-icat-direct "2.9.4"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clj-jargon "3.0.3"
+                 [org.cyverse/clj-jargon "3.0.4-SNAPSHOT"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [javax.servlet/servlet-api "2.5"]

--- a/src/data_info/routes.clj
+++ b/src/data_info/routes.clj
@@ -11,6 +11,7 @@
             [data-info.routes.data :as data-routes]
             [data-info.routes.exists :as exists-routes]
             [data-info.routes.filetypes :as filetypes-routes]
+            [data-info.routes.groups :as groups-routes]
             [data-info.routes.path-lists :as path-lists]
             [data-info.routes.permissions :as permission-routes]
             [data-info.routes.navigation :as navigation-routes]
@@ -41,7 +42,8 @@
                    {:name "bulk", :description "Bulk Operations"}
                    {:name "navigation", :description "Navigation"}
                    {:name "users", :description "User Operations"}
-                   {:name "filetypes", :description "File Type Metadata"}]}})
+                   {:name "filetypes", :description "File Type Metadata"}
+                   {:name "groups", :description "Group Operations"}]}})
   (middleware
     [add-user-to-context
      wrap-query-params
@@ -64,4 +66,5 @@
     ticket-routes/ticket-routes
     trash-routes/trash
     users-routes/users-routes
+    groups-routes/groups-routes
     (undocumented (route/not-found (svc/unrecognized-path-response)))))

--- a/src/data_info/routes/groups.clj
+++ b/src/data_info/routes/groups.clj
@@ -6,6 +6,12 @@
             [schema.core :as s]
             [ring.util.http-response :refer [ok]]))
 
+(s/defschema Group
+  {:group-name NonBlankString
+   :members [NonBlankString]})
+
+(s/defschema GroupMembers
+  (dissoc Group :group-name))
 
 (defroutes groups-routes
   (context "/groups" []
@@ -14,14 +20,9 @@
     (POST "/" []
       :middleware [otel-middleware]
       :query [params StandardUserQueryParams]
-      :body [body {:group-name
-                   NonBlankString
-
-                   (s/optional-key :members)
-                   [NonBlankString]}] ;; need to split out to proper defschema
+      :body [body Group] ;; need to split out to proper defschema
       :responses (merge CommonResponses
-                        {200 {:schema {:group-name NonBlankString
-                                       (s/optional-key :members) [NonBlankString]}
+                        {200 {:schema Group
                               :description "Successful response"}})
       :summary "Create group"
       :description (str "Create an IRODS group given a name and a list of members")
@@ -33,9 +34,8 @@
       (GET "/" []
         :middleware [otel-middleware]
         :query [{:keys [user]} StandardUserQueryParams]
-        :body [body s/Any] ;; obviously not
         :responses (merge CommonResponses
-                          {200 {:schema s/Any
+                          {200 {:schema Group
                                 :description "Successful response"}})
         :summary "List group members"
         :description (str "List an IRODS group & members given a name")
@@ -44,9 +44,9 @@
       (PUT "/" []
         :middleware [otel-middleware]
         :query [{:keys [user]} StandardUserQueryParams]
-        :body [body s/Any] ;; obviously not
+        :body [body GroupMembers] ;; obviously not
         :responses (merge CommonResponses
-                          {200 {:schema s/Any
+                          {200 {:schema Group
                                 :description "Successful response"}})
         :summary "Update group members"
         :description (str "Update an IRODS group's members")
@@ -55,9 +55,8 @@
       (DELETE "/" []
         :middleware [otel-middleware]
         :query [{:keys [user]} StandardUserQueryParams]
-        :body [body s/Any] ;; obviously not
         :responses (merge CommonResponses
-                          {200 {:schema s/Any
+                          {200 {:schema s/Any ;; probably could be better
                                 :description "Successful response"}})
         :summary "Delete group"
         :description (str "Delete an IRODS group's members")

--- a/src/data_info/routes/groups.clj
+++ b/src/data_info/routes/groups.clj
@@ -43,21 +43,21 @@
 
       (PUT "/" []
         :middleware [otel-middleware]
-        :query [{:keys [user]} StandardUserQueryParams]
-        :body [body GroupMembers] ;; obviously not
+        :query [params StandardUserQueryParams]
+        :body [body GroupMembers]
         :responses (merge CommonResponses
                           {200 {:schema Group
                                 :description "Successful response"}})
         :summary "Update group members"
         :description (str "Update an IRODS group's members")
-        (ok {}))
+        (ok (groups/update-group-members params body group-name)))
 
       (DELETE "/" []
         :middleware [otel-middleware]
-        :query [{:keys [user]} StandardUserQueryParams]
+        :query [params StandardUserQueryParams]
         :responses (merge CommonResponses
                           {200 {:schema s/Any ;; probably could be better
                                 :description "Successful response"}})
         :summary "Delete group"
         :description (str "Delete an IRODS group's members")
-        (ok {})))))
+        (ok (groups/delete-group params group-name))))))

--- a/src/data_info/routes/groups.clj
+++ b/src/data_info/routes/groups.clj
@@ -1,0 +1,59 @@
+(ns data-info.routes.groups
+  (:use [common-swagger-api.schema]
+        [otel.middleware :only [otel-middleware]]
+        [data-info.routes.schemas.users])
+  (:require [data-info.services.users :as users]
+            [schema.core :as s]
+            [ring.util.http-response :refer [ok]]))
+
+
+(defroutes groups-routes
+  (context "/groups" []
+    :tags ["groups"]
+
+    (POST "/" []
+      :middleware [otel-middleware]
+      :query [{:keys [user]} StandardUserQueryParams]
+      :body [body s/Any] ;; obviously not
+      :responses (merge CommonResponses
+                        {200 {:schema s/Any
+                              :description "Successful response"}})
+      :summary "Create group"
+      :description (str "Create an IRODS group given a name")
+      (ok {}))
+
+    (context ["/:group-name"] []
+      :path-params [group-name :- (describe NonBlankString "The name of an iRODS group, with or without zone qualification")]
+
+      (GET "/" []
+        :middleware [otel-middleware]
+        :query [{:keys [user]} StandardUserQueryParams]
+        :body [body s/Any] ;; obviously not
+        :responses (merge CommonResponses
+                          {200 {:schema s/Any
+                                :description "Successful response"}})
+        :summary "List group members"
+        :description (str "List an IRODS group & members given a name")
+        (ok {}))
+
+      (PUT "/" []
+        :middleware [otel-middleware]
+        :query [{:keys [user]} StandardUserQueryParams]
+        :body [body s/Any] ;; obviously not
+        :responses (merge CommonResponses
+                          {200 {:schema s/Any
+                                :description "Successful response"}})
+        :summary "Update group members"
+        :description (str "Update an IRODS group's members")
+        (ok {}))
+
+      (DELETE "/" []
+        :middleware [otel-middleware]
+        :query [{:keys [user]} StandardUserQueryParams]
+        :body [body s/Any] ;; obviously not
+        :responses (merge CommonResponses
+                          {200 {:schema s/Any
+                                :description "Successful response"}})
+        :summary "Delete group"
+        :description (str "Delete an IRODS group's members")
+        (ok {})))))

--- a/src/data_info/routes/groups.clj
+++ b/src/data_info/routes/groups.clj
@@ -18,45 +18,45 @@
     :tags ["groups"]
 
     (POST "/" []
-      :middleware [otel-middleware]
-      :query [params StandardUserQueryParams]
-      :body [body Group]
-      :responses (merge CommonResponses
-                        {200 {:schema Group
-                              :description "Successful response"}})
-      :summary "Create group"
-      :description (str "Create an IRODS group given a name and a list of members")
+      :middleware  [otel-middleware]
+      :query       [params StandardUserQueryParams]
+      :body        [body Group]
+      :responses   (merge CommonResponses
+                          {200 {:schema Group
+                                :description "Successful response"}})
+      :summary     "Create group"
+      :description "Create an IRODS group given a name and a list of members"
       (ok (groups/create-group params body)))
 
     (context ["/:group-name"] []
       :path-params [group-name :- (describe NonBlankString "The name of an iRODS group, with or without zone qualification")]
 
       (GET "/" []
-        :middleware [otel-middleware]
-        :query [params StandardUserQueryParams]
-        :responses (merge CommonResponses
-                          {200 {:schema Group
-                                :description "Successful response"}})
-        :summary "List group members"
-        :description (str "List an IRODS group & members given a name")
+        :middleware  [otel-middleware]
+        :query       [params StandardUserQueryParams]
+        :responses   (merge CommonResponses
+                            {200 {:schema Group
+                                  :description "Successful response"}})
+        :summary     "List group members"
+        :description "List an IRODS group & members given a name"
         (ok (groups/get-group params group-name)))
 
       (PUT "/" []
-        :middleware [otel-middleware]
-        :query [params StandardUserQueryParams]
-        :body [body GroupMembers]
-        :responses (merge CommonResponses
-                          {200 {:schema Group
-                                :description "Successful response"}})
-        :summary "Update group members"
-        :description (str "Update an IRODS group's members")
+        :middleware  [otel-middleware]
+        :query       [params StandardUserQueryParams]
+        :body        [body GroupMembers]
+        :responses   (merge CommonResponses
+                            {200 {:schema Group
+                                  :description "Successful response"}})
+        :summary     "Update group members"
+        :description "Update an IRODS group's members"
         (ok (groups/update-group-members params body group-name)))
 
       (DELETE "/" []
-        :middleware [otel-middleware]
-        :query [params StandardUserQueryParams]
-        :responses (merge CommonResponses
-                          {200 {:description "Successful response"}})
-        :summary "Delete group"
-        :description (str "Delete an IRODS group's members")
+        :middleware  [otel-middleware]
+        :query       [params StandardUserQueryParams]
+        :responses   (merge CommonResponses
+                            {200 {:description "Successful response"}})
+        :summary     "Delete group"
+        :description "Delete an IRODS group's members"
         (ok (groups/delete-group params group-name))))))

--- a/src/data_info/routes/groups.clj
+++ b/src/data_info/routes/groups.clj
@@ -2,7 +2,7 @@
   (:use [common-swagger-api.schema]
         [otel.middleware :only [otel-middleware]]
         [data-info.routes.schemas.users])
-  (:require [data-info.services.users :as users]
+  (:require [data-info.services.groups :as groups]
             [schema.core :as s]
             [ring.util.http-response :refer [ok]]))
 
@@ -13,14 +13,18 @@
 
     (POST "/" []
       :middleware [otel-middleware]
-      :query [{:keys [user]} StandardUserQueryParams]
-      :body [body s/Any] ;; obviously not
+      :query [params StandardUserQueryParams]
+      :body [body {:group-name
+                   NonBlankString
+
+                   (s/optional-key :members)
+                   [NonBlankString]}] ;; need to split out to proper defschema
       :responses (merge CommonResponses
                         {200 {:schema s/Any
                               :description "Successful response"}})
       :summary "Create group"
-      :description (str "Create an IRODS group given a name")
-      (ok {}))
+      :description (str "Create an IRODS group given a name and a list of members")
+      (ok (groups/create-group params body)))
 
     (context ["/:group-name"] []
       :path-params [group-name :- (describe NonBlankString "The name of an iRODS group, with or without zone qualification")]

--- a/src/data_info/routes/groups.clj
+++ b/src/data_info/routes/groups.clj
@@ -20,7 +20,8 @@
                    (s/optional-key :members)
                    [NonBlankString]}] ;; need to split out to proper defschema
       :responses (merge CommonResponses
-                        {200 {:schema s/Any
+                        {200 {:schema {:group-name NonBlankString
+                                       (s/optional-key :members) [NonBlankString]}
                               :description "Successful response"}})
       :summary "Create group"
       :description (str "Create an IRODS group given a name and a list of members")

--- a/src/data_info/routes/groups.clj
+++ b/src/data_info/routes/groups.clj
@@ -7,11 +7,11 @@
             [ring.util.http-response :refer [ok]]))
 
 (s/defschema Group
-  {:group-name NonBlankString
+  {:name NonBlankString
    :members [NonBlankString]})
 
 (s/defschema GroupMembers
-  (dissoc Group :group-name))
+  (dissoc Group :name))
 
 (defroutes groups-routes
   (context "/groups" []

--- a/src/data_info/routes/groups.clj
+++ b/src/data_info/routes/groups.clj
@@ -56,8 +56,7 @@
         :middleware [otel-middleware]
         :query [params StandardUserQueryParams]
         :responses (merge CommonResponses
-                          {200 {:schema s/Any ;; probably could be better
-                                :description "Successful response"}})
+                          {200 {:description "Successful response"}})
         :summary "Delete group"
         :description (str "Delete an IRODS group's members")
         (ok (groups/delete-group params group-name))))))

--- a/src/data_info/routes/groups.clj
+++ b/src/data_info/routes/groups.clj
@@ -20,7 +20,7 @@
     (POST "/" []
       :middleware [otel-middleware]
       :query [params StandardUserQueryParams]
-      :body [body Group] ;; need to split out to proper defschema
+      :body [body Group]
       :responses (merge CommonResponses
                         {200 {:schema Group
                               :description "Successful response"}})

--- a/src/data_info/routes/groups.clj
+++ b/src/data_info/routes/groups.clj
@@ -33,13 +33,13 @@
 
       (GET "/" []
         :middleware [otel-middleware]
-        :query [{:keys [user]} StandardUserQueryParams]
+        :query [params StandardUserQueryParams]
         :responses (merge CommonResponses
                           {200 {:schema Group
                                 :description "Successful response"}})
         :summary "List group members"
         :description (str "List an IRODS group & members given a name")
-        (ok {}))
+        (ok (groups/get-group params group-name)))
 
       (PUT "/" []
         :middleware [otel-middleware]

--- a/src/data_info/services/groups.clj
+++ b/src/data_info/services/groups.clj
@@ -1,6 +1,8 @@
 (ns data-info.services.groups
   (:require [clojure.tools.logging :as log]
+            [slingshot.slingshot :refer [throw+]]
             [clj-jargon.users :as users]
+            [clojure.string :as string]
             [data-info.services.users :as di-users]
             [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]))
@@ -16,7 +18,6 @@
   (irods/with-jargon-exceptions [cm]
     ;; need to validate
     (users/create-user-group cm group-name)
-    (log/info "group" group-name "should be created")
     (when (seq members)
       (dorun (map
                (partial users/add-to-group cm group-name)
@@ -24,9 +25,43 @@
     {:group-name group-name :members (users/list-group-members cm group-name)}))
 
 (defn update-group-members
-  [{user :user :as params} {group-name :group-name members :members}]
+  [{user :user :as params} {members :members} group-name]
   (irods/with-jargon-exceptions [cm]
-    {:group-name group-name :members (users/list-group-members cm group-name)}))
+    ;; validate
+    (let [current-members (users/list-group-members cm group-name)]
+      (loop [old-members (sort current-members)
+             new-members (sort members)]
+        ;; compare the head of both lists and determine if anything needs adding or removing
+        (let [c (first old-members)
+              n (first new-members)]
+          (cond
+            (and (nil? c) (nil? n))
+            nil ;; both lists are exhausted, we're done!
+
+            (or (nil? c) (and
+                           (not (nil? n))
+                           (neg? (compare (di-users/qualify-username n) c)))) ;; the new member isn't in the current members, should be added
+            (do
+              (users/add-to-group cm group-name n)
+              (recur old-members (rest new-members)))
+
+            (or (nil? n) (and
+                           (not (nil? c))
+                           (neg? (compare c (di-users/qualify-username n))))) ;; the old member isn't in the new list, should be removed
+            (do
+              (users/remove-from-group cm group-name (string/replace c (re-pattern (str "#" (:zone cm) "$")) ""))
+              (recur (rest old-members) new-members))
+
+            (= c (di-users/qualify-username n)) ;; already correct for both of these
+            (recur (rest old-members) (rest new-members))
+
+            :else
+            (throw+ {:error "Couldn't figure out what to do with users" :new n :old c}))))
+      {:group-name group-name :members (users/list-group-members cm group-name)})))
 
 (defn delete-group
-  [{user :user} group-name])
+  [{user :user} group-name]
+  (irods/with-jargon-exceptions [cm]
+    ;; validate
+    (users/delete-user-group cm group-name)
+    nil))

--- a/src/data_info/services/groups.clj
+++ b/src/data_info/services/groups.clj
@@ -3,6 +3,7 @@
             [slingshot.slingshot :refer [throw+]]
             [clj-jargon.users :as users]
             [clojure.string :as string]
+            [clojure.set :as cset]
             [data-info.services.users :as di-users]
             [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]
@@ -36,35 +37,17 @@
     (validators/user-is-group-admin cm user)
     (validators/group-exists cm group-name)
     (validators/all-users-exist cm members)
-    (let [current-members (users/list-group-members cm group-name)]
-      (loop [old-members (sort current-members)
-             new-members (sort members)]
-        ;; compare the head of both lists and determine if anything needs adding or removing
-        (let [c (first old-members)
-              n (first new-members)]
-          (cond
-            (and (nil? c) (nil? n))
-            nil ;; both lists are exhausted, we're done!
+    (let [current-members (set (users/list-group-members cm group-name))
+          desired-members (set (map di-users/ensure-qualified members))
 
-            (or (nil? c) (and
-                           (not (nil? n))
-                           (neg? (compare (di-users/qualify-username n) c)))) ;; the new member isn't in the current members, should be added
-            (do
-              (users/add-to-group cm group-name n)
-              (recur old-members (rest new-members)))
+          members-to-add (cset/difference desired-members current-members)
+          members-to-remove (cset/difference current-members desired-members)
 
-            (or (nil? n) (and
-                           (not (nil? c))
-                           (neg? (compare c (di-users/qualify-username n))))) ;; the old member isn't in the new list, should be removed
-            (do
-              (users/remove-from-group cm group-name (string/replace c (re-pattern (str "#" (:zone cm) "$")) ""))
-              (recur (rest old-members) new-members))
-
-            (= c (di-users/qualify-username n)) ;; already correct for both of these
-            (recur (rest old-members) (rest new-members))
-
-            :else
-            (throw+ {:error "Couldn't figure out what to do with users" :new n :old c}))))
+          unqualify (fn [name] (string/replace name (re-pattern (str "#\\Q" (:zone cm) "\\E$")) ""))
+          addfn (fn [user] (users/add-to-group cm group-name (unqualify user)))
+          rmfn (fn [user] (users/remove-from-group cm group-name (unqualify user)))]
+      (doall (map addfn members-to-add))
+      (doall (map rmfn members-to-remove))
       {:name group-name :members (users/list-group-members cm group-name)})))
 
 (defn delete-group

--- a/src/data_info/services/groups.clj
+++ b/src/data_info/services/groups.clj
@@ -5,6 +5,12 @@
             [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]))
 
+(defn get-group
+  [{user :user} group-name]
+  (irods/with-jargon-exceptions [cm]
+    ;; validate
+    {:group-name group-name :members (users/list-group-members cm group-name)}))
+
 (defn create-group
   [{user :user} {group-name :group-name members :members}]
   (irods/with-jargon-exceptions [cm]
@@ -16,3 +22,11 @@
                (partial users/add-to-group cm group-name)
                members)))
     {:group-name group-name :members (users/list-group-members cm group-name)}))
+
+(defn update-group-members
+  [{user :user :as params} {group-name :group-name members :members}]
+  (irods/with-jargon-exceptions [cm]
+    {:group-name group-name :members (users/list-group-members cm group-name)}))
+
+(defn delete-group
+  [{user :user} group-name])

--- a/src/data_info/services/groups.clj
+++ b/src/data_info/services/groups.clj
@@ -1,0 +1,18 @@
+(ns data-info.services.groups
+  (:require [clojure.tools.logging :as log]
+            [clj-jargon.users :as users]
+            [data-info.services.users :as di-users]
+            [data-info.util.config :as cfg]
+            [data-info.util.irods :as irods]))
+
+(defn create-group
+  [{user :user} {group-name :group-name members :members}]
+  (irods/with-jargon-exceptions [cm]
+    ;; need to validate
+    (users/create-user-group cm group-name)
+    (log/info "group" group-name "should be created")
+    (when (seq members)
+      (dorun (map
+               (partial users/add-to-group cm group-name)
+               members)))
+    {:group-name group-name :members (users/list-group-members cm group-name)}))

--- a/src/data_info/services/groups.clj
+++ b/src/data_info/services/groups.clj
@@ -13,10 +13,10 @@
   (irods/with-jargon-exceptions [cm]
     (validators/user-exists cm user)
     (validators/group-exists cm group-name)
-    {:group-name group-name :members (users/list-group-members cm group-name)}))
+    {:name group-name :members (users/list-group-members cm group-name)}))
 
 (defn create-group
-  [{user :user} {group-name :group-name members :members}]
+  [{user :user} {group-name :name members :members}]
   (irods/with-jargon-exceptions [cm]
     (validators/user-exists cm user)
     (validators/user-is-group-admin cm user)
@@ -27,7 +27,7 @@
       (dorun (map
                (partial users/add-to-group cm group-name)
                members)))
-    {:group-name group-name :members (users/list-group-members cm group-name)}))
+    {:name group-name :members (users/list-group-members cm group-name)}))
 
 (defn update-group-members
   [{user :user :as params} {members :members} group-name]
@@ -65,7 +65,7 @@
 
             :else
             (throw+ {:error "Couldn't figure out what to do with users" :new n :old c}))))
-      {:group-name group-name :members (users/list-group-members cm group-name)})))
+      {:name group-name :members (users/list-group-members cm group-name)})))
 
 (defn delete-group
   [{user :user} group-name]

--- a/src/data_info/services/users.clj
+++ b/src/data_info/services/users.clj
@@ -17,6 +17,12 @@
   [name]
   (str name \# (cfg/irods-zone)))
 
+(defn ensure-qualified
+  [name]
+  (if (re-find #"#" name)
+    name
+    (qualify-username name)))
+
 (defn do-list-qualified-user-groups
   [user username]
   (irods/with-jargon-exceptions :client-user user [cm]

--- a/src/data_info/util/validators.clj
+++ b/src/data_info/util/validators.clj
@@ -196,6 +196,23 @@
     (init/with-jargon (cfg/jargon-cfg) [cm]
       (user-exists cm user))))
 
+(defn user-is-group-admin
+  [cm username]
+  (let [user (user/user cm username)]
+    (when-not (some #{(:type user)} [:admin :group-admin])
+      (throw+ {:error_code error/ERR_FORBIDDEN})))) ;; maybe a better code, but idk
+
+(defn group-exists
+  [cm group]
+  (when-not (user/group-exists? cm group)
+    (throw+ {:error_code error/ERR_DOES_NOT_EXIST
+             :group group})))
+
+(defn group-does-not-exist
+  [cm group]
+  (when (user/group-exists? cm group)
+    (throw+ {:error_code error/ERR_EXISTS
+             :group group})))
 
 (defn user-owns-path
   [cm user path]


### PR DESCRIPTION
This depends on cyverse-de/clj-jargon#15 and once that's merged I'll update the version number here.

This adds CRUD endpoints for groups in IRODS, to be used by the indexing service that will sync Grouper groups into IRODS.