### PR TITLE
Do async-tasks service updates in a thread pool to allow them to be non-blocking

### DIFF
--- a/src/data_info/clients/async_tasks.clj
+++ b/src/data_info/clients/async_tasks.clj
@@ -34,8 +34,8 @@
                                      (apply retry-with-handler retries handler f args)
                                      (catch Object o
                                        {::error o})))))
-    (delay (if (::error @ag)
-      (throw+ (::error @ag))
+    (delay (if-let [err (::error @ag)]
+      (throw+ err)
       @ag))))
 
 (defn get-by-id

--- a/src/data_info/clients/async_tasks.clj
+++ b/src/data_info/clients/async_tasks.clj
@@ -52,8 +52,7 @@
 
 (defn add-status
   [id status]
-  (async-tasks-client/add-status (config/async-tasks-client) id status)
-  (log/info "successfully added status"))
+  (async-tasks-client/add-status (config/async-tasks-client) id status))
 
 (defn add-completed-status
   [id status]


### PR DESCRIPTION
(for the intermediate updates -- start and end statuses it'll run it in the thread pool but wait for it to return before continuing/exiting)

This is also so I can add a sleep in so it won't just spam async-tasks as fast as it can when it ends up needing to retry.

Also, hopefully this is the last PR for this for a while :sweat_smile: 