### PR TITLE
CORE-1893 Update clj-jargon to v3.1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [org.cyverse/clj-icat-direct "2.9.4"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clj-jargon "3.0.4"
+                 [org.cyverse/clj-jargon "3.1.0-SNAPSHOT"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [javax.servlet/servlet-api "2.5"]

--- a/src/data_info/services/sharing.clj
+++ b/src/data_info/services/sharing.clj
@@ -49,7 +49,7 @@
           item being shared is a directory."
   [cm user share-with perm fpath]
   (let [hdir      (share-path-home fpath)
-        trash-dir (trash-base-dir (:zone cm) user)
+        trash-dir (trash-base-dir (:zone cm))
         base-dirs #{hdir trash-dir}]
     (log/warn fpath "is being shared with" share-with "by" user)
     (process-parent-dirs (partial set-readable cm share-with true) #(not (base-dirs %)) fpath)
@@ -121,7 +121,7 @@
        3. Remove the user's read permissions for parent directories in which the user no longer has
           access to any other files or subdirectories."
   [cm user unshare-with fpath]
-  (let [trash-base (trash-base-dir (:zone cm) user)
+  (let [trash-base (trash-base-dir (:zone cm))
         path-base  (share-path-home fpath)
         base-dirs #{path-base trash-base}]
     (log/warn "Removing permissions on" fpath "from" unshare-with "by" user)

--- a/src/data_info/util/paths.clj
+++ b/src/data_info/util/paths.clj
@@ -15,12 +15,12 @@
 
 (defn ^String base-trash-path
   []
-  (item/trash-base-dir (cfg/irods-zone) (cfg/irods-user)))
+  (item/trash-base-dir (cfg/irods-zone)))
 
 
 (defn ^String user-trash-path
   [^String user]
-  (ft/path-join (base-trash-path) user))
+  (item/trash-base-dir (cfg/irods-zone) user))
 
 
 (defn ^Boolean in-trash?


### PR DESCRIPTION
This PR will also update calls to `clj-jargon.item-info/trash-base-dir`, which no longer requires a user param, so that items can be put into the same trash paths as used by `irm`.