### PR TITLE
CORE-1183: make path-list-creator async

### DIFF
--- a/src/data_info/clients/async_tasks.clj
+++ b/src/data_info/clients/async_tasks.clj
@@ -77,9 +77,9 @@
     async-task-id))
 
 (defn paths-async-thread
-  ([async-task-id jargon-fn end-fn]
-   (paths-async-thread async-task-id jargon-fn end-fn true))
-  ([async-task-id jargon-fn end-fn use-client-user?]
+  ([async-task-id irods-fn end-fn]
+   (paths-async-thread async-task-id irods-fn end-fn true :jargon))
+  ([async-task-id irods-fn end-fn use-client-user? conn-type]
    (otel/with-span [s ["paths-async-thread" {:attributes {"async-task-id" (str async-task-id)}}]]
      (let [pool (make-threadpool (str async-task-id "-async-tasks-update") 1)
            {:keys [username] :as async-task} (get-by-id async-task-id)
@@ -95,16 +95,24 @@
            (fn [e t] (log/error (:throwable t) "failed updating async task with started status"))
            add-status async-task-id {:status "started"}))
          (if use-client-user?
-           (irods/with-jargon-exceptions :client-user username [cm]
-             (otel/with-span [s ["jargon-fn" {:attributes {"client-user" username}}]]
-               (jargon-fn cm async-task update-fn)))
-           (irods/with-jargon-exceptions [cm]
-             (otel/with-span [s ["jargon-fn"]]
-               (jargon-fn cm async-task update-fn))))
-           ;; For the completed statuses we want a lot of retries because the presence or absence of an end date controls locking behavior
-           (deref (retry-via-threadpool pool 100
-             (fn [e t] (log/error (:throwable t) "failed updating async task with completed status"))
-             add-completed-status async-task-id {:status "completed" :detail (str "[" (config/service-identifier) "]")}))
+           (if (= conn-type :jargon)
+             (irods/with-jargon-exceptions :client-user username [cm]
+               (otel/with-span [s ["irods-fn" {:attributes {"client-user" username}}]]
+                 (irods-fn cm async-task update-fn)))
+             (irods/with-irods-exceptions {:jargon-opts {:client-user username}} irods
+               (otel/with-span [s ["irods-fn" {:attributes {"client-user" username}}]]
+                 (irods-fn irods async-task update-fn))))
+           (if (= conn-type :jargon)
+             (irods/with-jargon-exceptions [cm]
+               (otel/with-span [s ["irods-fn"]]
+                 (irods-fn cm async-task update-fn)))
+             (irods/with-irods-exceptions {} irods
+               (otel/with-span [s ["irods-fn"]]
+                 (irods-fn irods async-task update-fn)))))
+         ;; For the completed statuses we want a lot of retries because the presence or absence of an end date controls locking behavior
+         (deref (retry-via-threadpool pool 100
+           (fn [e t] (log/error (:throwable t) "failed updating async task with completed status"))
+           add-completed-status async-task-id {:status "completed" :detail (str "[" (config/service-identifier) "]")}))
          (otel/with-span [s ["end-fn"]]
            (end-fn async-task false))
          (catch Object _

--- a/src/data_info/clients/notifications.clj
+++ b/src/data_info/clients/notifications.clj
@@ -62,6 +62,13 @@
      :message (str (completed-text failed?) " restoring " (string/join ", " start-paths) " to " (string/join ", " end-paths))}
     user "restore" end-paths))
 
+(defn path-list-notification
+  [user input-paths created-path failed?]
+  (amend-notification
+    {:subject (str (completed-text failed?) " creating path list " created-path " from " (count input-paths) " file(s)/folder(s)")
+     :message (str (completed-text failed?) " creating path list " created-path " from: " (string/join ", " input-paths))}
+    user "path-list" created-path))
+
 (defn empty-trash-notification
   [user failed?]
   {:type "data"

--- a/src/data_info/routes/path_lists.clj
+++ b/src/data_info/routes/path_lists.clj
@@ -15,7 +15,8 @@
           :middleware [otel-middleware]
           :query [params PathListSaveQueryParams]
           :body [body (describe Paths "The folder or file paths to process for the HT Path List file contents.")]
-          :responses {200 {:schema      FileStat
+          :responses {200 {:schema      {:file (describe FilteredStatInfo "File info")
+                                         :async-task-id (describe NonBlankString "An asynchronous task ID for the path list creation being handled in the background")}
                            :description "File info for the saved HT Path List file."}}
           :summary "Create an HT Path List File"
           :description

--- a/src/data_info/services/path_lists.clj
+++ b/src/data_info/services/path_lists.clj
@@ -189,4 +189,5 @@
     (let [async-task-id (async-tasks/run-async-thread
                           (rename/new-task "create-path-list" user {:dest dest :path-list-info-type path-list-info-type :name-pattern name-pattern :info-type info-type :folders-only folders-only :recursive recursive :paths paths})
                           create-path-list-thread "create-path-list")]
-      {:async-task-id async-task-id})))
+      {:file {:path dest}
+       :async-task-id async-task-id})))

--- a/src/data_info/services/path_lists.clj
+++ b/src/data_info/services/path_lists.clj
@@ -9,7 +9,9 @@
             [clj-irods.validate :refer [validate]]
             [clj-jargon.permissions :as perms]
             [otel.otel :as otel]
+            [data-info.clients.async-tasks :as async-tasks]
             [data-info.services.filetypes :as filetypes]
+            [data-info.services.rename :as rename]
             [data-info.services.stat :as stat]
             [data-info.services.stat.common :refer [process-filters]]
             [data-info.services.stat.jargon :as jargon-stat]
@@ -135,30 +137,49 @@
     (doseq [path paths]
       (validators/not-base-path user path))))
 
-(defn create-path-list
+(defn create-path-list*
   "Creates an HT Path List file from the given set of paths and filtering params.
    The resulting HT Path List file will contain only file or only folder paths (depending on the `folders-only` param),
    but no paths of folders in the initial given list will be included.
    If `recursive` is true, then all subfolders (plus all their files and subfolders)
    of any given folder paths are parsed and filtered as well.
    Throws an error if the filtering params result in no matching paths."
+  [irods {:keys [user dest path-list-info-type name-pattern info-type folders-only recursive]
+    :or   {path-list-info-type (cfg/ht-path-list-info-type)}}
+   {:keys [paths]}]
+  (otel/with-span [s ["create-path-list"]]
+    (validate-request-paths irods user dest paths)
+
+    (let [path-list-contents  (paths->path-list irods
+                                                user
+                                                (info-type->file-identifier path-list-info-type)
+                                                name-pattern
+                                                info-type
+                                                folders-only
+                                                recursive
+                                                paths)
+          path-list-file-stat (with-in-str path-list-contents (copy-stream @(:jargon irods) *in* user dest))]
+      (irods/with-jargon-exceptions [admin-cm]
+        (filetypes/add-type-to-validated-path admin-cm dest path-list-info-type))
+      (rods/invalidate irods dest)
+      {:file (stat/decorate-stat irods user (cfg/irods-zone) path-list-file-stat (process-filters nil nil))})))
+
+(defn- create-path-list-thread
+  [async-task-id]
+  (let [irods-fn (fn [irods async-task update-fn]
+                   (let [{:keys [username data]} async-task]
+                     (create-path-list* irods data (:paths data))))
+        end-fn (fn [async-task failed?])]
+    (async-tasks/paths-async-thread async-task-id irods-fn end-fn true :irods)))
+
+(defn create-path-list
   [{:keys [user dest path-list-info-type name-pattern info-type folders-only recursive]
     :or   {path-list-info-type (cfg/ht-path-list-info-type)}}
    {:keys [paths]}]
   (otel/with-span [s ["create-path-list"]]
     (irods/with-irods-exceptions {:jargon-opts {:client-user user}} irods
-      (validate-request-paths irods user dest paths)
-
-      (let [path-list-contents  (paths->path-list irods
-                                                  user
-                                                  (info-type->file-identifier path-list-info-type)
-                                                  name-pattern
-                                                  info-type
-                                                  folders-only
-                                                  recursive
-                                                  paths)
-            path-list-file-stat (with-in-str path-list-contents (copy-stream @(:jargon irods) *in* user dest))]
-        (irods/with-jargon-exceptions [admin-cm]
-          (filetypes/add-type-to-validated-path admin-cm dest path-list-info-type))
-        (rods/invalidate irods dest)
-        {:file (stat/decorate-stat irods user (cfg/irods-zone) path-list-file-stat (process-filters nil nil))}))))
+      (validate-request-paths irods user dest paths))
+    (let [async-task-id (async-tasks/run-async-thread
+                          (rename/new-task "create-path-list" user {:dest dest :path-list-info-type path-list-info-type :name-pattern name-pattern :info-type info-type :folders-only folders-only :recursive recursive :paths paths})
+                          create-path-list-thread "create-path-list")]
+      {:async-task-id async-task-id})))

--- a/src/data_info/services/path_lists.clj
+++ b/src/data_info/services/path_lists.clj
@@ -10,6 +10,7 @@
             [clj-jargon.permissions :as perms]
             [otel.otel :as otel]
             [data-info.clients.async-tasks :as async-tasks]
+            [data-info.clients.notifications :as notifications]
             [data-info.services.filetypes :as filetypes]
             [data-info.services.rename :as rename]
             [data-info.services.stat :as stat]
@@ -169,7 +170,13 @@
   (let [irods-fn (fn [irods async-task update-fn]
                    (let [{:keys [username data]} async-task]
                      (create-path-list* irods data (:paths data))))
-        end-fn (fn [async-task failed?])]
+        end-fn (fn [async-task failed?]
+                   (notifications/send-notification
+                     (notifications/path-list-notification
+                       (:username async-task)
+                       (:paths async-task)
+                       (:dest async-task)
+                       failed?)))]
     (async-tasks/paths-async-thread async-task-id irods-fn end-fn true :irods)))
 
 (defn create-path-list

--- a/src/data_info/services/trash.clj
+++ b/src/data_info/services/trash.clj
@@ -86,7 +86,7 @@
                    (when (seq trashed-paths)
                      (notifications/send-notification
                        (notifications/trash-notification (:username async-task) trashed-paths trash-paths failed?)))))]
-    (async-tasks/paths-async-thread async-task-id jargon-fn end-fn false))) ;; we don't use a client user so we can delete tickets
+    (async-tasks/paths-async-thread async-task-id jargon-fn end-fn false :jargon))) ;; we don't use a client user so we can delete tickets
 
 (defn- delete-paths
   ([user paths]
@@ -160,7 +160,7 @@
                  (amqp/publish-msg (str "index.usage.data.user." (:username async-task)) "Update requested by data-info")
                  (notifications/send-notification
                    (notifications/empty-trash-notification (:username async-task) failed?)))]
-    (async-tasks/paths-async-thread async-task-id jargon-fn end-fn false))) ;; no client user, for backwards compatibility
+    (async-tasks/paths-async-thread async-task-id jargon-fn end-fn false :jargon))) ;; no client user, for backwards compatibility
 
 (defn- delete-trash
   "Permanently delete the contents of a user's trash directory."


### PR DESCRIPTION
Basically a couple things here:

a.) make it so `paths-async-thread` can do _either_ a plain jargon thread or one that uses clj-irods instead
b.) moving the path-list creation into a thread/async task
c.) adding a notification at the end
d.) updating the schema for the endpoint to not necessarily include full file info & to include an async task

I think there's probably sonora updates needed too, hoping to check on that next.