### PR TITLE
CORE-2004: filter the list of members by existence in iRODS rather than erroring

### DIFF
--- a/src/data_info/services/groups.clj
+++ b/src/data_info/services/groups.clj
@@ -36,9 +36,11 @@
     (validators/user-exists cm user)
     (validators/user-is-group-admin cm user)
     (validators/group-exists cm group-name)
-    (validators/all-users-exist cm members)
+    ;; instead of this, we filter the list by extant users, so the group can
+    ;; still be updated if a few don't exist in irods
+    ;(validators/all-users-exist cm members)
     (let [current-members (set (users/list-group-members cm group-name))
-          desired-members (set (map di-users/ensure-qualified members))
+          desired-members (set (map di-users/ensure-qualified (filter users/user-exists? members)))
 
           members-to-add (cset/difference desired-members current-members)
           members-to-remove (cset/difference current-members desired-members)


### PR DESCRIPTION
This doesn't do everything within CORE-2004 because it doesn't alert admins when users are missing. I'm not sure how critical that is to include.