### PR TITLE
CORE-2006: update the `dire` dependency again

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                                 [com.fasterxml.jackson.core/jackson-databind]
                                 [com.fasterxml.jackson.core/jackson-core]]]
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
-                 [org.cyverse/dire "0.5.5"]
+                 [org.cyverse/dire "0.5.6-SNAPSHOT"]
                  [me.raynes/fs "1.4.6"]
                  [org.apache.tika/tika-core "2.9.2" :exclusions [org.slf4j/slf4j-api]]
                  [net.sf.opencsv/opencsv "2.3"]

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "data-info-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.11.3"]
+  :dependencies [[org.clojure/clojure "1.11.4"]
                  [cheshire "5.13.0"
                    :exclusions [[com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]
                                 [com.fasterxml.jackson.dataformat/jackson-dataformat-smile]


### PR DESCRIPTION
This is a minor change to switch to a new version of `org.clojure/dire`. While I was at it, I also switched to a new version of Clojure that was just released.