### PR TITLE
Fix a schema validation error for group deletion requests.

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,14 +1,17 @@
-apiVersion: skaffold/v1
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: data-info
-deploy:
-  kubectl:
-    manifests:
-    - k8s/data-info.yml
 build:
+  artifacts:
+    - image: harbor.cyverse.org/de/data-info
   tagPolicy:
     gitCommit: {}
-  artifacts:
-  - image: harbor.cyverse.org/de/data-info
   local: {}
+  platforms:
+    - "linux/amd64"
+manifests:
+  rawYaml:
+    - k8s/data-info.yml
+deploy:
+  kubectl: {}

--- a/src/data_info/routes/groups.clj
+++ b/src/data_info/routes/groups.clj
@@ -41,6 +41,9 @@
   (assoc GroupErrorResponses
          :error_code DeleteErrorCodes))
 
+(s/defschema GroupDeleted
+  {:name (describe String "group name")})
+
 (defroutes groups-routes
   (context "/groups" []
     :tags ["groups"]
@@ -94,7 +97,8 @@
                                   :description data-schema/CommonErrorCodeDocs}}
                             {403 {:schema ErrorResponseForbidden
                                   :description "No access to group administration"}}
-                            {200 {:description "Successful response"}})
+                            {200 {:schema GroupDeleted
+                                  :description "Successful response"}})
         :summary     "Delete group"
         :description "Delete an IRODS group's members"
         (ok (groups/delete-group params group-name))))))

--- a/src/data_info/services/groups.clj
+++ b/src/data_info/services/groups.clj
@@ -59,4 +59,4 @@
     (validators/user-is-group-admin cm user)
     (when (users/group-exists? cm group-name)
       (users/delete-user-group cm group-name))
-    nil))
+    {:name group-name}))


### PR DESCRIPTION
We kept getting `(not (map? nil))` errors, and I didn't have any luck telling schema to just ignore that and return an empty response instead. I ended up making up a response body and returning it instead.