### PR TITLE
CORE-2072: switch to a newer version of Jargon.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                    :exclusions [[org.slf4j/slf4j-api]
                                 [org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clj-jargon "3.1.3-SNAPSHOT"
+                 [org.cyverse/clj-jargon "3.1.3"
                    :exclusions [[org.slf4j/slf4j-api]
                                 [org.slf4j/slf4j-log4j12]
                                 [log4j]]]

--- a/project.clj
+++ b/project.clj
@@ -14,8 +14,8 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "data-info-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.11.4"]
-                 [cheshire "5.13.0"
+  :dependencies [[org.clojure/clojure "1.12.1"]
+                 [cheshire "6.0.0"
                    :exclusions [[com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]
                                 [com.fasterxml.jackson.dataformat/jackson-dataformat-smile]
                                 [com.fasterxml.jackson.core/jackson-annotations]
@@ -24,7 +24,7 @@
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
                  [org.cyverse/dire "0.5.6"]
                  [me.raynes/fs "1.4.6"]
-                 [org.apache.tika/tika-core "2.9.2" :exclusions [org.slf4j/slf4j-api]]
+                 [org.apache.tika/tika-core "3.2.2" :exclusions [org.slf4j/slf4j-api]]
                  [net.sf.opencsv/opencsv "2.3"]
                  [org.cyverse/clj-irods "0.3.8"]
                  [org.cyverse/clj-icat-direct "2.9.7"
@@ -37,19 +37,19 @@
                                 [log4j]]]
                  [javax.servlet/servlet-api "2.5"]
                  [metosin/compojure-api "1.1.14"]
-                 [ring/ring-jetty-adapter "1.12.2" :exclusions [org.slf4j/slf4j-api]]
-                 [org.cyverse/clojure-commons "3.0.9"]
+                 [ring/ring-jetty-adapter "1.14.2" :exclusions [org.slf4j/slf4j-api]]
+                 [org.cyverse/clojure-commons "3.0.11"]
                  [org.cyverse/common-cli "2.8.2"]
                  [org.cyverse/common-cfg "2.8.3"]
-                 [org.cyverse/common-swagger-api "3.4.5"]
+                 [org.cyverse/common-swagger-api "3.4.12"]
                  [org.cyverse/heuristomancer "2.8.7"]
                  [org.cyverse/kameleon "3.0.10"]
-                 [org.cyverse/metadata-client "3.1.2"]
+                 [org.cyverse/metadata-client "3.2.0"]
                  [org.cyverse/async-tasks-client "0.0.5"]
                  [org.cyverse/metadata-files "2.1.1"]
                  [org.cyverse/oai-ore "1.0.4"]
                  [org.cyverse/service-logging "2.8.4"]
-                 [com.novemberain/langohr "5.4.0"]
+                 [com.novemberain/langohr "5.6.0"]
                  [slingshot "0.12.2"]]
   :eastwood {:exclude-namespaces [data-info.routes.schemas.tickets
                                   data-info.routes.schemas.stats
@@ -58,7 +58,7 @@
                                   :test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
   :plugins [[jonase/eastwood "1.4.3"]
-            [lein-ancient "0.7.0"]
+            [lein-ancient "1.0.0-RC3"]
             [test2junit "1.4.4"]]
   :profiles {:dev     {:plugins        [[lein-ring "0.12.5"]]
                        :resource-paths ["conf/test"]}

--- a/project.clj
+++ b/project.clj
@@ -26,12 +26,12 @@
                  [me.raynes/fs "1.4.6"]
                  [org.apache.tika/tika-core "3.2.2" :exclusions [org.slf4j/slf4j-api]]
                  [net.sf.opencsv/opencsv "2.3"]
-                 [org.cyverse/clj-irods "0.3.8"]
+                 [org.cyverse/clj-irods "0.3.9-SNAPSHOT"]
                  [org.cyverse/clj-icat-direct "2.9.7"
                    :exclusions [[org.slf4j/slf4j-api]
                                 [org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clj-jargon "3.1.2"
+                 [org.cyverse/clj-jargon "3.1.3-SNAPSHOT"
                    :exclusions [[org.slf4j/slf4j-api]
                                 [org.slf4j/slf4j-log4j12]
                                 [log4j]]]


### PR DESCRIPTION
Thankfully, this only requires dependency updates.