### PR TITLE
Preserve non-ASCII filenames on download (RFC 6266 Content-Disposition)

### DIFF
--- a/src/data_info/services/entry.clj
+++ b/src/data_info/services/entry.clj
@@ -4,6 +4,7 @@
   (:require [me.raynes.fs :as fs]
             [clj-icat-direct.icat :as icat]
             [clojure.java.io :as io]
+            [clojure.string :as string]
             [clj-jargon.init :refer [proxy-input-stream-return clean-return]]
             [clj-irods.core :as rods]
             [clj-jargon.by-uuid :as uuid]
@@ -17,7 +18,8 @@
             [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]
             [data-info.util.validators :as duv]
-            [ring.util.http-response :as http-response]))
+            [ring.util.http-response :as http-response])
+  (:import [java.net URLEncoder]))
 
 
 ;; id specific
@@ -45,17 +47,33 @@
     (clean-return (:jargon irods) "")
     (proxy-input-stream-return (:jargon irods) @istream-ref)))
 
+(defn- rfc5987-encode
+  "Percent-encodes filename as UTF-8 for an RFC 5987 filename* parameter."
+  [filename]
+  (-> (URLEncoder/encode filename "UTF-8")
+      (string/replace "+" "%20")
+      (string/replace "*" "%2A")))
+
+(defn- content-disposition
+  "Builds an RFC 6266 Content-Disposition value. filename* carries the real
+   UTF-8 name and stays pure ASCII on the wire, so characters above U+00FF
+   survive the ISO-8859-1 header transport that would otherwise strip them.
+   filename= is an ASCII fallback for legacy clients."
+  [attachment filename]
+  (let [dtype    (if attachment "attachment" "inline")
+        fallback (-> filename
+                     (string/replace #"[^\x20-\x7E]" "_")
+                     (string/replace #"[\"\\]" "_"))]
+    (str dtype "; filename=\"" fallback "\"; filename*=UTF-8''" (rfc5987-encode filename))))
+
 (defn- file-entry
   [irods path {:keys [user attachment]}]
-  (let [filename    (str \" (file/basename path) \")
+  (let [filename    (file/basename path)
         istream-ref (delay (io/input-stream (ops/input-stream @(:jargon irods) path)))
-        disposition (if attachment
-                      (str "attachment; filename=" filename)
-                      (str "filename=" filename))
         media-type  (irods/detect-media-type (:jargon irods) path istream-ref)]
     (assoc (http-response/ok (get-file irods user path istream-ref))
            :headers {"Content-Type"        media-type
-                     "Content-Disposition" disposition})))
+                     "Content-Disposition" (content-disposition attachment filename)})))
 
 
 ; folder specific

--- a/test/data_info/services/entry_test.clj
+++ b/test/data_info/services/entry_test.clj
@@ -1,0 +1,37 @@
+(ns data-info.services.entry-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :as string]
+            [data-info.services.entry :as entry])
+  (:import [java.net URLDecoder]))
+
+(def ^:private content-disposition #'entry/content-disposition)
+
+(defn- ascii-only? [s]
+  (every? #(< (int %) 128) s))
+
+(defn- filename*-value [header]
+  (second (re-find #"filename\*=UTF-8''(\S+)" header)))
+
+(deftest content-disposition-preserves-non-ascii
+  ;; ä/ö/ü are <= U+00FF and survived the old code; ł/ō are > U+00FF and were
+  ;; stripped by the ISO-8859-1 header transport. Both must round-trip now.
+  (let [filename "test-ä-ö-ü-ł-ō.txt"
+        header   (content-disposition true filename)]
+    (testing "the header is pure ASCII, so it survives the ISO-8859-1 header transport"
+      (is (ascii-only? header)))
+    (testing "filename* round-trips back to the original UTF-8 name"
+      (is (= filename (URLDecoder/decode (filename*-value header) "UTF-8"))))
+    (testing "no raw non-ASCII characters leak into the header"
+      (is (not (string/includes? header "ł"))))))
+
+(deftest content-disposition-fallback-is-safe
+  (testing "characters that would break a quoted filename= are replaced in the fallback"
+    (let [header (content-disposition true "a\"b\\c.txt")]
+      (is (string/includes? header "filename=\"a_b_c.txt\""))
+      (testing "but filename* preserves them exactly"
+        (is (= "a\"b\\c.txt" (URLDecoder/decode (filename*-value header) "UTF-8")))))))
+
+(deftest content-disposition-disposition-type
+  (are [attachment expected] (string/starts-with? (content-disposition attachment "f.txt") expected)
+    true  "attachment;"
+    false "inline;"))


### PR DESCRIPTION
## Problem

Downloading a file whose name contains characters **above U+00FF** (e.g. `ł`, `ō`) strips those characters from the downloaded filename. Reproduced via the web UI: downloading `test-ä-ö-ü-ł-ō.txt` yields a file whose name has `ł` and `ō` removed. The `ä`/`ö`/`ü` characters were preserved; only the above-Latin-1 characters were lost.

## Root cause

`file-entry` (`src/data_info/services/entry.clj`) built the `Content-Disposition` header by concatenating the raw filename into a plain `filename=` parameter. HTTP header values are transported as ISO-8859-1, which cannot represent code points above U+00FF, so Jetty drops those characters when serializing the header.

Latin-1 characters (`ä`/`ö`/`ü`, all ≤ U+00FF) survived only by coincidence: ISO-8859-1 is also the fallback charset browsers use to decode a plain `filename=` value, so the byte round-tripped. Anything above U+00FF had no representation in the header at all.

This is on the download path and is independent of the upload fix in terrain (cyverse-de/terrain#329).

## Fix

Emit an RFC 6266 header:

```
Content-Disposition: attachment; filename="<ascii-fallback>"; filename*=UTF-8''<percent-encoded-utf8>
```

- `filename*` carries the real name, percent-encoded as UTF-8. That value is **pure ASCII on the wire**, so it survives the ISO-8859-1 header transport (and the terrain → sonora proxy chain) intact, and modern browsers decode it back to the original name.
- `filename=` is retained as a sanitized ASCII fallback (non-ASCII and quote/backslash replaced with `_`) for legacy clients.

## Tests

`test/data_info/services/entry_test.clj`:

- `content-disposition-preserves-non-ascii` — asserts the header is pure ASCII (the property that makes it survive transport), that `filename*` round-trips back to `test-ä-ö-ü-ł-ō.txt`, and that no raw non-ASCII leaks into the header.
- `content-disposition-fallback-is-safe` — quote/backslash in a name can't break the quoted `filename=`, while `filename*` still preserves them.
- `content-disposition-disposition-type` — `attachment` vs `inline` disposition type.

Verified the tests fail if the header is reverted to the raw `filename=`. `lein test` (full suite) and `lein check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)