### PR TITLE
Make file uploads atomic (fix spurious ERR_EXISTS) and give uploads a longer idle timeout

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:linters {:redundant-ignore {:level :off}}}

--- a/.clj-kondo/imports/clj-kondo/slingshot/clj_kondo/slingshot/try_plus.clj
+++ b/.clj-kondo/imports/clj-kondo/slingshot/clj_kondo/slingshot/try_plus.clj
@@ -1,0 +1,44 @@
+(ns clj-kondo.slingshot.try-plus
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn expand-catch [catch-node]
+  (let [[catch catchee & exprs] (:children catch-node)
+        catchee-sexpr (api/sexpr catchee)]
+    (cond (vector? catchee-sexpr)
+          (let [[selector & exprs] exprs]
+            (api/list-node
+             [catch (api/token-node 'Exception) (api/token-node '_e#)
+              (api/list-node
+               (list* (api/token-node 'let)
+                      (api/vector-node [selector (api/token-node nil)])
+                      exprs))]))
+          :else catch-node)))
+
+(defn try+ [{:keys [node]}]
+  (let [children (rest (:children node))
+        [body catches]
+        (loop [body children
+               body-exprs []
+               catches []]
+          (if (seq body)
+            (let [f (first body)
+                  f-sexpr (api/sexpr f)]
+              (if (and (seq? f-sexpr) (= 'catch (first f-sexpr)))
+                (recur (rest body)
+                       body-exprs
+                       (conj catches (expand-catch f)))
+                (recur (rest body)
+                       (conj body-exprs f)
+                       catches)))
+            [body-exprs catches]))
+        new-node (api/list-node
+                  [(api/token-node 'let)
+                   (api/vector-node
+                    [(api/token-node '&throw-context) (api/token-node nil)])
+                   (api/token-node '&throw-context) ;; use throw-context to avoid warning
+                   (with-meta (api/list-node (list* (api/token-node 'try)
+                                                    (concat body catches)))
+                     (meta node))])]
+    ;; (prn (api/sexpr new-node))
+    {:node new-node}))
+

--- a/.clj-kondo/imports/clj-kondo/slingshot/config.edn
+++ b/.clj-kondo/imports/clj-kondo/slingshot/config.edn
@@ -1,0 +1,2 @@
+{:hooks
+ {:analyze-call {slingshot.slingshot/try+ clj-kondo.slingshot.try-plus/try+}}}

--- a/.clj-kondo/imports/instaparse/config.edn
+++ b/.clj-kondo/imports/instaparse/config.edn
@@ -1,0 +1,2 @@
+{:lint-as {instaparse.macros/defclone clojure.core/def
+           instaparse.macros/set-global-var! clojure.core/set!}}

--- a/.clj-kondo/imports/org.cyverse/clojure-commons/clojure_commons/config.clj
+++ b/.clj-kondo/imports/org.cyverse/clojure-commons/clojure_commons/config.clj
@@ -1,0 +1,135 @@
+(ns clojure-commons.config)
+
+(defn record-missing-prop
+  "Records a property that is missing.  Instead of failing on the first missing parameter, we log
+   the missing parameter, mark the configuration as invalid and keep going so that we can log as
+   many configuration errors as possible in one run.
+
+   Parameters:
+       prop-name    - the name of the property.
+       config-valid - a ref containing a validity flag."
+  [_prop-name _config-valid])
+
+(defn get-required-prop
+  "Gets a required property from a set of properties.
+
+   Parameters:
+       props        - a ref containing the properties.
+       prop-name    - the name of the property.
+       config-valid - a ref containing a validity flag."
+  [props prop-name config-valid]
+  (let [value (get @props prop-name "")]
+    (when (empty? value)
+      (record-missing-prop prop-name config-valid))
+    value))
+
+(defn get-optional-prop
+  "Gets an optional property from a set of properties.
+
+   Parameters:
+       props        - a ref containing the properties.
+       prop-name    - the name of the property.
+       config-valid - a ref containing a validity flag.
+       default      - the default property value."
+  ([props prop-name _config-valid]
+     (get @props prop-name ""))
+  ([props prop-name _config-valid default]
+     (get @props prop-name default)))
+
+(defn- wrap-extraction-fn
+  "Places a property extraction function in an appropriate wrapper, depending on whether or not
+   the property is flagged. This function depends on the fact that property validation is done
+   in the extraction function itself. For flagged properties that are disabled, the extraction
+   function is not called when the value is retrieved. Therefore the validation for disabled
+   properties is skipped because the extraction function isn't called.
+
+   Parameters:
+       extraction-fn - the actual extraction function.
+       flag-props    - the feature flag properties determining if the property is relevant."
+  [extraction-fn flag-props]
+  (if (empty? flag-props)
+    `(memoize ~extraction-fn)
+    `(memoize (fn [] (when (some identity ~(vec flag-props)) (~extraction-fn))))))
+
+(defn define-property
+  "Defines a property. This is a helper function that performs common tasks required by all of the
+   defprop macros.
+
+   Parameters:
+       sym           - the symbol to define.
+       desc          - a brief description of the property.
+       configs       - a ref containing the list of config settings.
+       flag-props    - the feature flag properties determining if the property is relevant.
+       extraction-fn - the function used to extract the property value."
+  [sym desc configs flag-props extraction-fn]
+  (let [wrapped-extraction-fn (wrap-extraction-fn extraction-fn flag-props)]
+    `(conj ~configs (def ~sym ~desc ~wrapped-extraction-fn))))
+
+(defn define-required-property
+  "Defines a required property. This is a helper function that performs common tasks required by
+   the macros for required properties.
+
+   Parameters:
+       sym           - the symbol to define.
+       desc          - a brief description of the property.
+       props         - a ref containing the properties.
+       config-valid  - a ref containing the validity flag.
+       configs       - a ref containing the list of config settings.
+       flag-props    - the feature flag properties determining if the property is relevant.
+       prop-name     - the name of the property.
+       extraction-fn - the function used to extract the property value."
+  [sym desc [props config-valid configs flag-props] prop-name extraction-fn]
+  (define-property sym desc configs flag-props
+    `(fn [] (~extraction-fn ~props ~prop-name ~config-valid))))
+
+(defn define-optional-property
+  "Defines an optional property. This is a helper function that performs common tasks required by
+   the macros for optional properties.
+
+   Parameters:
+       sym           - the symbol to define.
+       desc          - a brief description of the property.
+       props         - a ref containing the properties.
+       config-valid  - a ref containing the validity flag.
+       configs       - a ref containing the list of config settings.
+       flag-props    - the feature flag properties determining if the property is relevant.
+       prop-name     - the name of the property.
+       extraction-fn - the function used to extract the property value.
+       default-value - the default value for the property."
+  [sym desc [props config-valid configs flag-props] prop-name extraction-fn default-value]
+  (define-property sym desc configs flag-props
+    `(fn [] (~extraction-fn ~props ~prop-name ~config-valid ~default-value))))
+
+(defmacro defprop-str
+  "defines a required string property.
+
+   Parameters:
+       sym          - the symbol to define.
+       desc         - a brief description of the property.
+       props        - a ref containing the properties.
+       config-valid - a ref containing a validity flag.
+       configs      - a ref containing the list of config settings.
+       flag-props   - the feature flag properties determining if the property is relevant.
+       prop-name    - the name of the property."
+  [sym desc [props config-valid configs & flag-props] prop-name]
+  (define-required-property
+    sym desc [props config-valid configs flag-props] prop-name get-required-prop))
+
+(defmacro defprop-optstr
+  "Defines an optional string property.
+
+   Parameters:
+       sym          - the symbol to define.
+       desc         - a brief description of the property.
+       props        - a ref containing the properties.
+       config-valid - a ref containing a validity flag.
+       configs      - a ref containing the list of config settings.
+       flag-props   - the feature flag properties determining if the property is relevant.
+       prop-name    - the name of the property.
+       default      - the default value."
+  ([sym desc [props config-valid configs & flag-props] prop-name]
+     (define-optional-property
+       sym desc [props config-valid configs flag-props] prop-name get-optional-prop ""))
+  ([sym desc [props config-valid configs & flag-props] prop-name default]
+     (define-optional-property
+       sym desc [props config-valid configs flag-props] prop-name get-optional-prop default)))

--- a/.clj-kondo/imports/org.cyverse/clojure-commons/clojure_commons/core.clj
+++ b/.clj-kondo/imports/org.cyverse/clojure-commons/clojure_commons/core.clj
@@ -1,0 +1,8 @@
+(ns clojure-commons.core)
+
+(defmacro when-let*
+  ([bindings & body]
+   (if (seq bindings)
+     `(when-let [~(first bindings) ~(second bindings)]
+        (when-let* ~(drop 2 bindings) ~@body))
+     `(do ~@body))))

--- a/.clj-kondo/imports/org.cyverse/clojure-commons/clojure_commons/error_codes.clj
+++ b/.clj-kondo/imports/org.cyverse/clojure-commons/clojure_commons/error_codes.clj
@@ -1,0 +1,5 @@
+(ns clojure-commons.error-codes)
+
+(defmacro deferr
+  [sym]
+  `(def ~sym (name (quote ~sym))))

--- a/.clj-kondo/imports/org.cyverse/clojure-commons/clojure_commons/file_utils.clj
+++ b/.clj-kondo/imports/org.cyverse/clojure-commons/clojure_commons/file_utils.clj
@@ -1,0 +1,16 @@
+(ns clj-kondo.exports.org.cyverse.clojure-commons.clojure-commons.file-utils)
+
+(defn random-str
+  []
+  (let [allowed-chars "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"]
+    (apply str (map (partial nth allowed-chars) (take 16 (repeatedly #(int (* (rand) (count allowed-chars)))))))))
+
+(defmacro with-temp-dir
+  [sym prefix _err-fn & body]
+  `(let [~sym (str ~prefix (random-str))]
+     ~@body))
+
+(defmacro with-temp-dir-in
+  [sym parent prefix _err-fn & body]
+  `(let [~sym (str ~parent "/" ~prefix (random-str))]
+     ~@body))

--- a/.clj-kondo/imports/org.cyverse/clojure-commons/config.edn
+++ b/.clj-kondo/imports/org.cyverse/clojure-commons/config.edn
@@ -1,0 +1,18 @@
+{:hooks
+ {:macroexpand
+  {clojure-commons.config/defprop-str          clojure-commons.config/defprop-str
+   clojure-commons.config/defprop-optstr       clojure-commons.config/defprop-optstr
+   clojure-commons.config/defprop-vec          clojure-commons.config/defprop-str
+   clojure-commons.config/defprop-optvec       clojure-commons.config/defprop-optstr
+   clojure-commons.config/defprop-int          clojure-commons.config/defprop-str
+   clojure-commons.config/defprop-optint       clojure-commons.config/defprop-optstr
+   clojure-commons.config/defprop-long         clojure-commons.config/defprop-str
+   clojure-commons.config/defprop-optlong      clojure-commons.config/defprop-optstr
+   clojure-commons.config/defprop-boolean      clojure-commons.config/defprop-str
+   clojure-commons.config/defprop-optboolean   clojure-commons.config/defprop-optstr
+   clojure-commons.config/defprop-uuid         clojure-commons.config/defprop-str
+   clojure-commons.config/defprop-optuuid      clojure-commons.config/defprop-optstr
+   clojure-commons.error-codes/deferr          clojure-commons.error-codes/deferr
+   clojure-commons.file-utils/with-temp-dir    clojure-commons.file-utils/with-temp-dir
+   clojure-commons.file-utils/with-temp-dir-in clojure-commons.file-utils/with-temp-dir-in
+   clojure-commons.core/when-let*              clojure-commons.core/when-let*}}}

--- a/.clj-kondo/imports/potemkin/potemkin/config.edn
+++ b/.clj-kondo/imports/potemkin/potemkin/config.edn
@@ -1,0 +1,62 @@
+{:lint-as {potemkin.collections/compile-if      clojure.core/if
+           potemkin.collections/reify-map-type  clojure.core/reify
+           potemkin.collections/def-map-type    clj-kondo.lint-as/def-catch-all
+           potemkin.collections/def-derived-map clj-kondo.lint-as/def-catch-all
+
+           potemkin.types/reify+                clojure.core/reify
+           potemkin.types/defprotocol+          clojure.core/defprotocol
+           potemkin.types/deftype+              clojure.core/deftype
+           potemkin.types/defrecord+            clojure.core/defrecord
+           potemkin.types/definterface+         clojure.core/defprotocol
+           potemkin.types/extend-protocol+      clojure.core/extend-protocol
+           potemkin.types/def-abstract-type     clj-kondo.lint-as/def-catch-all
+
+           potemkin.utils/doit                  clojure.core/doseq
+           potemkin.utils/doary                 clojure.core/doseq
+           potemkin.utils/condp-case            clojure.core/condp
+           potemkin.utils/fast-bound-fn         clojure.core/bound-fn
+
+           potemkin.walk/prewalk                clojure.walk/prewalk
+           potemkin.walk/postwalk               clojure.walk/postwalk
+           potemkin.walk/walk                   clojure.walk/walk
+
+           ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+           ;;;; top-level from import-vars
+           ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+           ;; Have hooks
+           ;;potemkin/import-fn potemkin.namespaces/import-fn
+           ;;potemkin/import-macro potemkin.namespaces/import-macro
+           ;;potemkin/import-def potemkin.namespaces/import-def
+
+           ;; Internal, not transitive
+           ;;potemkin/unify-gensyms               potemkin.macros/unify-gensyms
+           ;;potemkin/normalize-gensyms           potemkin.macros/normalize-gensyms
+           ;;potemkin/equivalent?                 potemkin.macros/equivalent?
+
+           potemkin/condp-case                  clojure.core/condp
+           potemkin/doit                        potemkin.utils/doit
+           potemkin/doary                       potemkin.utils/doary
+
+           potemkin/def-abstract-type           clj-kondo.lint-as/def-catch-all
+           potemkin/reify+                      clojure.core/reify
+           potemkin/defprotocol+                clojure.core/defprotocol
+           potemkin/deftype+                    clojure.core/deftype
+           potemkin/defrecord+                  clojure.core/defrecord
+           potemkin/definterface+               clojure.core/defprotocol
+           potemkin/extend-protocol+            clojure.core/extend-protocol
+
+           potemkin/reify-map-type              clojure.core/reify
+           potemkin/def-derived-map             clj-kondo.lint-as/def-catch-all
+           potemkin/def-map-type                clj-kondo.lint-as/def-catch-all}
+
+ ;; leave import-vars alone, kondo special-cases it
+ :hooks   {:macroexpand {#_#_potemkin.namespaces/import-vars potemkin.namespaces/import-vars
+                         potemkin.namespaces/import-fn    potemkin.namespaces/import-fn
+                         potemkin.namespaces/import-macro potemkin.namespaces/import-macro
+                         potemkin.namespaces/import-def   potemkin.namespaces/import-def
+
+                         #_#_potemkin/import-vars potemkin.namespaces/import-vars
+                         potemkin/import-fn               potemkin.namespaces/import-fn
+                         potemkin/import-macro            potemkin.namespaces/import-macro
+                         potemkin/import-def              potemkin.namespaces/import-def}}}

--- a/.clj-kondo/imports/potemkin/potemkin/potemkin/namespaces.clj
+++ b/.clj-kondo/imports/potemkin/potemkin/potemkin/namespaces.clj
@@ -1,0 +1,56 @@
+(ns potemkin.namespaces
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn import-macro*
+  ([sym]
+   `(def ~(-> sym name symbol) ~sym))
+  ([sym name]
+   `(def ~name ~sym)))
+
+(defmacro import-fn
+  ([sym]
+   (import-macro* sym))
+  ([sym name]
+   (import-macro* sym name)))
+
+(defmacro import-macro
+  ([sym]
+   (import-macro* sym))
+  ([sym name]
+   (import-macro* sym name)))
+
+(defmacro import-def
+  ([sym]
+   (import-macro* sym))
+  ([sym name]
+   (import-macro* sym name)))
+
+#_
+(defmacro import-vars
+  "Imports a list of vars from other namespaces."
+  [& syms]
+  (let [unravel (fn unravel [x]
+                  (if (sequential? x)
+                    (->> x
+                         rest
+                         (mapcat unravel)
+                         (map
+                           #(symbol
+                              (str (first x)
+                                   (when-let [n (namespace %)]
+                                     (str "." n)))
+                              (name %))))
+                    [x]))
+        syms (mapcat unravel syms)
+        result `(do
+                  ~@(map
+                      (fn [sym]
+                        (let [vr (resolve sym)
+                              m (meta vr)]
+                          (cond
+                            (nil? vr) `(throw (ex-info (format "`%s` does not exist" '~sym) {}))
+                            (:macro m) `(def ~(-> sym name symbol) ~sym)
+                            (:arglists m) `(def ~(-> sym name symbol) ~sym)
+                            :else `(def ~(-> sym name symbol) ~sym))))
+                      syms))]
+    result))

--- a/.clj-kondo/imports/rewrite-clj/rewrite-clj/config.edn
+++ b/.clj-kondo/imports/rewrite-clj/rewrite-clj/config.edn
@@ -1,0 +1,5 @@
+{:lint-as
+ {rewrite-clj.zip/subedit-> clojure.core/->
+  rewrite-clj.zip/subedit->> clojure.core/->>
+  rewrite-clj.zip/edit-> clojure.core/->
+  rewrite-clj.zip/edit->> clojure.core/->>}}

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,5 @@ test2junit
 telepresence.log
 data-info.properties
 .eastwood
-.clj-kondo
+.clj-kondo/.cache
 .lsp

--- a/src/data_info/core.clj
+++ b/src/data_info/core.clj
@@ -57,6 +57,7 @@
     (config/load-config-from-file path)))
 
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var :unused-public-var]}
 (defn lein-ring-init
   []
   (load-configuration-from-file)
@@ -64,6 +65,7 @@
   (amqp/connect!))
 
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var :unused-public-var]}
 (defn repl-init
   []
   (load-configuration-from-file)
@@ -93,11 +95,9 @@
 (defn -main
   [& args]
   (tc/with-logging-context config/svc-info
-    (let [{:keys [options arguments errors summary]} (ccli/handle-args config/svc-info
-                                                                       args
-                                                                       cli-options)]
+    (let [{:keys [options]} (ccli/handle-args config/svc-info args cli-options)]
       (when-not (fs/exists? (:config options))
-        (ccli/exit 1 (str "The config file does not exist.")))
+        (ccli/exit 1 "The config file does not exist."))
       (when-not (fs/readable? (:config options))
         (ccli/exit 1 "The config file is not readable."))
       (load-configuration-from-file (:config options))

--- a/src/data_info/core.clj
+++ b/src/data_info/core.clj
@@ -4,6 +4,7 @@
             [clojure.tools.logging :as log]
             [data-info.routes :as routes]
             [data-info.util.config :as config]
+            [data-info.util.jetty :as jetty]
             [data-info.amqp :as amqp]
             [me.raynes.fs :as fs]
             [common-cli.core :as ccli]
@@ -81,7 +82,13 @@
   []
   (require 'ring.adapter.jetty)
   (log/warn "Started listening on" (config/listen-port))
-  ((eval 'ring.adapter.jetty/run-jetty) routes/app {:port (config/listen-port)}))
+  ((eval 'ring.adapter.jetty/run-jetty) routes/app
+   {:port          (config/listen-port)
+    :max-idle-time (config/jetty-max-idle-time)
+    :configurator  (jetty/idle-timeout-configurator
+                    (fn [^String path] (and path (.startsWith path "/data")))
+                    (config/jetty-max-idle-time)
+                    (config/jetty-upload-idle-time))}))
 
 (defn -main
   [& args]

--- a/src/data_info/core.clj
+++ b/src/data_info/core.clj
@@ -88,7 +88,9 @@
    {:port          (config/listen-port)
     :max-idle-time (config/jetty-max-idle-time)
     :configurator  (jetty/idle-timeout-configurator
-                    (fn [^String path] (and path (.startsWith path "/data")))
+                    (fn [^String method ^String path]
+                      (or (and (= method "POST") (re-matches #"/data/?" path))
+                          (and (= method "PUT") (re-matches #"/data/[^/]+/?" path))))
                     (config/jetty-max-idle-time)
                     (config/jetty-upload-idle-time))}))
 

--- a/src/data_info/services/write.clj
+++ b/src/data_info/services/write.clj
@@ -10,6 +10,7 @@
             [clj-irods.validate :refer [validate]]
             [heuristomancer.core :as hm]
             [ring.middleware.multipart-params :as multipart]
+            [data-info.clients.async-tasks :as async-tasks]
             [data-info.services.stat :as stat]
             [data-info.services.stat.common :refer [process-filters]]
             [data-info.util.config :as cfg]
@@ -86,27 +87,53 @@
       (throw (ex-info "temp upload object still present after delete" {:path write-path})))
     true))
 
+(defn- cleanup-temp-object
+  "Thread body for a temp-upload-cleanup async task. iRODS locks the just-aborted replica for a
+   short time, so an immediate delete fails; this retries delete-temp-object with backoff until
+   the lock clears (or attempts are exhausted), recording the outcome on the async task."
+  [async-task-id]
+  (try
+    (let [write-path (:path (:data (async-tasks/get-by-id async-task-id)))
+          detail     (str "[" (cfg/service-identifier) "] " write-path)
+          mark       (fn [add-fn status]
+                       (try
+                         (add-fn async-task-id {:status status :detail detail})
+                         (catch Throwable e
+                           (log/error e "failed to record" status "status for partial upload cleanup"))))]
+      (mark async-tasks/add-status "running")
+      (loop [attempts 6, wait-ms 3000]
+        (Thread/sleep wait-ms)
+        (let [done? (try (delete-temp-object write-path)
+                         (catch Throwable e
+                           (log/debug e "deferred cleanup pending for partial upload" write-path)
+                           false))]
+          (cond
+            done?           (do (log/info "cleaned up partial upload object" write-path)
+                                (mark async-tasks/add-completed-status "completed"))
+            (pos? attempts) (recur (dec attempts) (min 30000 (* 2 wait-ms)))
+            :else           (do (log/warn "gave up cleaning up partial upload object" write-path)
+                                (mark async-tasks/add-completed-status "failed"))))))
+    (catch Throwable e
+      (log/error e "partial upload cleanup task failed" async-task-id))))
+
 (defn- schedule-temp-cleanup
-  "Deferred, best-effort cleanup of an orphaned temp upload object. iRODS locks the
-   just-aborted replica for a short time, so a synchronous delete fails; this retries with
-   backoff on a background daemon thread until the lock clears (or attempts are exhausted)."
-  [write-path]
-  (doto (Thread.
-         ^Runnable
-         (fn []
-           (loop [attempts 6, wait-ms 3000]
-             (Thread/sleep wait-ms)
-             (let [done? (try (delete-temp-object write-path)
-                              (catch Throwable e
-                                (log/debug e "deferred cleanup pending for partial upload" write-path)
-                                false))]
-               (cond
-                 done?          (log/info "cleaned up partial upload object" write-path)
-                 (pos? attempts) (recur (dec attempts) (min 30000 (* 2 wait-ms)))
-                 :else          (log/warn "gave up cleaning up partial upload object" write-path)))))
-         "upload-temp-cleanup")
-    (.setDaemon true)
-    (.start)))
+  "Registers a tracked async task to clean up an orphaned temp upload object and processes it on
+   a background thread (see cleanup-temp-object). Best-effort: a failure to register the task is
+   logged and swallowed so it never masks the upload error that triggered the cleanup."
+  [write-path user]
+  (try
+    (async-tasks/run-async-thread
+     (async-tasks/create-task
+      {:type      "data-upload-cleanup"
+       :username  user
+       :data      {:path write-path :instance-id (cfg/service-identifier)}
+       :statuses  [{:status "registered" :detail (str "[" (cfg/service-identifier) "]")}]
+       :behaviors [{:type "statuschangetimeout"
+                    :data {:statuses [{:start_status "running" :end_status "detected-stalled" :timeout "10m"}]}}]})
+     cleanup-temp-object
+     "upload-temp-cleanup")
+    (catch Throwable e
+      (log/error e "failed to schedule cleanup of partial upload object" write-path))))
 
 (defn- write-stream
   "Streams istream to dest-path and returns the stat of dest-path.
@@ -124,7 +151,7 @@
         (ops/move cm write-path dest-path :user user)
         (info/stat cm dest-path)
         (catch Throwable t
-          (schedule-temp-cleanup write-path)
+          (schedule-temp-cleanup write-path user)
           (throw t))))))
 
 (defn- save-file-contents

--- a/src/data_info/services/write.clj
+++ b/src/data_info/services/write.clj
@@ -52,13 +52,84 @@
           (meta/add-metadata cm path (cfg/type-detect-type-attribute) info-type "ipc-data-info-detected" :known-type :file)
           info-type))))
 
+(defn- temp-partial-path
+  "Returns a hidden temp path in the same collection as dest-path. Keeping the temp object
+   in the same collection makes the final rename a catalog-only (atomic) operation and
+   avoids any cross-collection permission fix-ups (see clj-jargon move/fix-perms)."
+  [dest-path]
+  (ft/path-join (ft/dirname dest-path)
+                (str "." (ft/basename dest-path) ".partial-" (java.util.UUID/randomUUID))))
+
+(defn- delete-temp-object
+  "Best-effort delete of an orphaned temp upload object on a FRESH connection (the client
+   connection is typically broken by the same I/O failure that aborted the upload). Tries a
+   hard delete, falling back to a trash (catalog-only) delete. Returns true when the object
+   is gone. Throws if the object still exists and cannot be removed (e.g. the replica is
+   still locked)."
+  [write-path]
+  (irods/with-jargon-exceptions [cm]
+    (when (info/exists? cm write-path)
+      (try
+        (ops/delete cm write-path true)
+        (catch Throwable _
+          (ops/delete cm write-path false))))
+    (when (info/exists? cm write-path)
+      (throw (ex-info "temp upload object still present after delete" {:path write-path})))
+    true))
+
+(defn- schedule-temp-cleanup
+  "Deferred, best-effort cleanup of an orphaned temp upload object. iRODS locks the
+   just-aborted replica for a short time, so a synchronous delete fails; this retries with
+   backoff on a background daemon thread until the lock clears (or attempts are exhausted)."
+  [write-path]
+  (doto (Thread.
+         ^Runnable
+         (fn []
+           (loop [attempts 6, wait-ms 3000]
+             (Thread/sleep wait-ms)
+             (let [done? (try (delete-temp-object write-path)
+                              (catch Throwable e
+                                (log/debug e "deferred cleanup pending for partial upload" write-path)
+                                false))]
+               (cond
+                 done?          (log/info "cleaned up partial upload object" write-path)
+                 (pos? attempts) (recur (dec attempts) (min 30000 (* 2 wait-ms)))
+                 :else          (log/warn "gave up cleaning up partial upload object" write-path)))))
+         "upload-temp-cleanup")
+    (.setDaemon true)
+    (.start)))
+
+(defn- write-stream
+  "Streams istream to dest-path and returns the stat of dest-path.
+
+   When atomic? is true, the bytes are written to a temp object in the same collection and
+   renamed into place only on success. This keeps a new-file create atomic: an interrupted
+   upload never leaves a partial object at dest-path (which would otherwise cause a spurious
+   ERR_EXISTS on the next attempt). The orphaned temp object is cleaned up asynchronously."
+  [cm istream user dest-path set-owner? atomic?]
+  (if-not atomic?
+    (ops/copy-stream cm istream user dest-path :set-owner? set-owner?)
+    (let [write-path (temp-partial-path dest-path)]
+      (try
+        (ops/copy-stream cm istream user write-path :set-owner? set-owner?)
+        (ops/move cm write-path dest-path :user user)
+        (info/stat cm dest-path)
+        (catch Throwable t
+          (schedule-temp-cleanup write-path)
+          (throw t))))))
+
 (defn- save-file-contents
-  "Save an istream to a destination. Relies on upstream functions to validate."
-  [irods istream-raw user dest-path set-owner?]
-  (let [istream-ref (delay (io/input-stream istream-raw))
+  "Save an istream to a destination. Relies on upstream functions to validate.
+
+   When atomic? is true (new-file creates), the contents are streamed to a temp object and
+   renamed into place on success so an interrupted upload never orphans a partial file at
+   dest-path."
+  [irods istream-raw user dest-path set-owner? atomic?]
+  (let [cm          @(:jargon irods)
+        istream-ref (delay (io/input-stream istream-raw))
         media-type (irods/detect-media-type (:jargon irods) dest-path istream-ref)
         info-type (get-info-type istream-ref)
-        base-stat (ops/copy-stream @(:jargon irods) @istream-ref user dest-path :set-owner? set-owner?)
+        base-stat (write-stream cm @istream-ref user dest-path set-owner? atomic?)
         final-info-type (irods/with-jargon-exceptions [admin-cm] (set-info-type admin-cm dest-path @info-type))]
     (log/info "Detected info-type:" @info-type ", final type:" final-info-type)
     (rods/invalidate irods dest-path)
@@ -77,7 +148,7 @@
               [:path-not-exists dest-path user (cfg/irods-zone)]
               [:path-exists dest-dir user (cfg/irods-zone)]
               [:path-writeable dest-dir user (cfg/irods-zone)])
-    (save-file-contents irods istream user dest-path true)))
+    (save-file-contents irods istream user dest-path true true)))
 
 (defn- overwrite-path
   "Save new contents for the file at dest-path from istream.
@@ -88,7 +159,7 @@
             [:path-exists dest-path user (cfg/irods-zone)]
             [:path-is-file dest-path user (cfg/irods-zone)]
             [:path-readable dest-path user (cfg/irods-zone)])
-  (save-file-contents irods istream user dest-path false))
+  (save-file-contents irods istream user dest-path false false))
 
 (defn- multipart-create-handler
   "When partially applied, creates a storage handler for

--- a/src/data_info/services/write.clj
+++ b/src/data_info/services/write.clj
@@ -1,18 +1,17 @@
 (ns data-info.services.write
   (:require [clojure-commons.file-utils :as ft]
-            [clojure-commons.error-codes :as ce]
             [clojure.tools.logging :as log]
             [clojure.java.io :as io]
             [clj-jargon.item-info :as info]
             [clj-jargon.item-ops :as ops]
             [clj-jargon.metadata :as meta]
+            [clj-jargon.validations :as cv]
             [clj-irods.core :as rods]
             [clj-irods.validate :refer [validate]]
             [heuristomancer.core :as hm]
             [ring.middleware.multipart-params :as multipart]
             [data-info.services.stat :as stat]
             [data-info.services.stat.common :refer [process-filters]]
-            [data-info.services.uuids :as uuids]
             [data-info.util.config :as cfg]
             [data-info.util.irods :as irods]
             [data-info.util.validators :as validators])
@@ -55,10 +54,20 @@
 (defn- temp-partial-path
   "Returns a hidden temp path in the same collection as dest-path. Keeping the temp object
    in the same collection makes the final rename a catalog-only (atomic) operation and
-   avoids any cross-collection permission fix-ups (see clj-jargon move/fix-perms)."
+   avoids any cross-collection permission fix-ups (see clj-jargon move/fix-perms). If either
+   the temporary file name or the file path exceeds the name or path length limit then a
+   fallback temporary file path is returned instead."
   [dest-path]
-  (ft/path-join (ft/dirname dest-path)
-                (str "." (ft/basename dest-path) ".partial-" (java.util.UUID/randomUUID))))
+  (let [dirname        (ft/dirname dest-path)
+        basename       (ft/basename dest-path)
+        suffix         (str ".partial-" (java.util.UUID/randomUUID))
+        candidate-name (str "." basename suffix)
+        candidate-path (ft/path-join dirname candidate-name)
+        fallback-path  (ft/path-join dirname suffix)]
+    (if (or (> (count candidate-name) cv/max-filename-length)
+            (> (count candidate-path) cv/max-path-length))
+      fallback-path
+      candidate-path)))
 
 (defn- delete-temp-object
   "Best-effort delete of an orphaned temp upload object on a FRESH connection (the client

--- a/src/data_info/util/config.clj
+++ b/src/data_info/util/config.clj
@@ -66,6 +66,19 @@
   [props config-valid configs]
   "data-info.port" 60000)
 
+(cc/defprop-optint jetty-max-idle-time
+  "The default maximum idle time (in milliseconds) for a Jetty connection. Kept short; it
+   applies to every endpoint except uploads, which use jetty-upload-idle-time instead."
+  [props config-valid configs]
+  "data-info.jetty.max-idle-time" 200000)
+
+(cc/defprop-optint jetty-upload-idle-time
+  "The maximum idle time (in milliseconds) applied to upload endpoints (POST/PUT /data).
+   Raised well above the short default so slow or intermittently-stalled uploads are not cut
+   off mid-transfer."
+  [props config-valid configs]
+  "data-info.jetty.upload-idle-time" 3600000)
+
 
 (cc/defprop-optvec perms-filter
   "The list of users who should be filtered out of permissions requests, comma-separated."

--- a/src/data_info/util/jetty.clj
+++ b/src/data_info/util/jetty.clj
@@ -1,0 +1,31 @@
+(ns data-info.util.jetty
+  "Jetty customization: per-endpoint connection idle timeouts.
+
+   The ring-jetty adapter exposes only a single connector-level idle timeout, so a longer
+   grace period for slow uploads would otherwise apply to every endpoint. Installing an
+   HttpConfiguration customizer lets us keep a short default idle timeout while raising it
+   only for the (long-lived, streaming) upload endpoints."
+  (:import [org.eclipse.jetty.server Server Connector HttpConnectionFactory HttpConfiguration$Customizer]))
+
+(defn- idle-timeout-customizer
+  "A per-request Jetty customizer. Sets the connection's idle timeout to upload-idle-ms for
+   requests whose path satisfies upload-path?, and to default-idle-ms otherwise (so the value
+   is correct even when a connection is reused across requests)."
+  [upload-path? ^long default-idle-ms ^long upload-idle-ms]
+  (reify HttpConfiguration$Customizer
+    (customize [_ request _response-headers]
+      (let [endpoint (.. request getConnectionMetaData getConnection getEndPoint)
+            path     (.. request getHttpURI getPath)]
+        (.setIdleTimeout endpoint (if (upload-path? path) upload-idle-ms default-idle-ms)))
+      request)))
+
+(defn idle-timeout-configurator
+  "Returns a ring-jetty :configurator fn that installs idle-timeout-customizer on every HTTP
+   connection factory of the server."
+  [upload-path? default-idle-ms upload-idle-ms]
+  (fn [^Server server]
+    (let [customizer (idle-timeout-customizer upload-path? (long default-idle-ms) (long upload-idle-ms))]
+      (doseq [^Connector connector (.getConnectors server)
+              factory              (.getConnectionFactories connector)
+              :when                (instance? HttpConnectionFactory factory)]
+        (.addCustomizer (.getHttpConfiguration ^HttpConnectionFactory factory) customizer)))))

--- a/src/data_info/util/jetty.clj
+++ b/src/data_info/util/jetty.clj
@@ -8,23 +8,24 @@
   (:import [org.eclipse.jetty.server Server Connector HttpConnectionFactory HttpConfiguration$Customizer]))
 
 (defn- idle-timeout-customizer
-  "A per-request Jetty customizer. Sets the connection's idle timeout to upload-idle-ms for
-   requests whose path satisfies upload-path?, and to default-idle-ms otherwise (so the value
-   is correct even when a connection is reused across requests)."
-  [upload-path? ^long default-idle-ms ^long upload-idle-ms]
+  "A per-request Jetty customizer. Sets the connection's idle timeout to upload-idle-ms
+  for requests whose method and path satisfy requires-long-timeout?, and to default-idle-ms
+  otherwise (so the value is correct even when a connection is reused across requests)."
+  [requires-long-timeout? ^long default-idle-ms ^long upload-idle-ms]
   (reify HttpConfiguration$Customizer
     (customize [_ request _response-headers]
       (let [endpoint (.. request getConnectionMetaData getConnection getEndPoint)
+            method   (.. request getMethod)
             path     (.. request getHttpURI getPath)]
-        (.setIdleTimeout endpoint (if (upload-path? path) upload-idle-ms default-idle-ms)))
+        (.setIdleTimeout endpoint (if (requires-long-timeout? method path) upload-idle-ms default-idle-ms)))
       request)))
 
 (defn idle-timeout-configurator
   "Returns a ring-jetty :configurator fn that installs idle-timeout-customizer on every HTTP
    connection factory of the server."
-  [upload-path? default-idle-ms upload-idle-ms]
+  [requires-long-timeout? default-idle-ms upload-idle-ms]
   (fn [^Server server]
-    (let [customizer (idle-timeout-customizer upload-path? (long default-idle-ms) (long upload-idle-ms))]
+    (let [customizer (idle-timeout-customizer requires-long-timeout? (long default-idle-ms) (long upload-idle-ms))]
       (doseq [^Connector connector (.getConnectors server)
               factory              (.getConnectionFactories connector)
               :when                (instance? HttpConnectionFactory factory)]


### PR DESCRIPTION
## Problem

Large file uploads over slow/flaky connections failed two ways:

1. An **`ERR_EXISTS`** after several minutes, even when the destination file did **not** exist before the upload started.
2. An **I/O timeout after ~200s of socket inactivity**.

## Root cause

The create path opened the iRODS write stream with `WRITE_TRUNCATE`, which registers the catalog entry the instant the stream opens — before the upload finishes. If the transfer died mid-stream (e.g. a stall hitting the unconfigured 200s Jetty idle timeout), a partial/0-byte object was **orphaned at the destination**. The next attempt then failed the `:path-not-exists` check with `ERR_EXISTS`. So "the file didn't exist before I started" was true — the *first, failed attempt* created it.

Separately, `run-jetty` used Jetty's default 200000 ms idle timeout, which cut off slow/intermittently-stalled uploads.

## Changes

- **Atomic create** (`services/write.clj`): new-file uploads stream to a hidden `.<name>.partial-<uuid>` object in the same collection and are `move`/renamed into place only on success (a catalog-only, atomic op). An interrupted upload no longer orphans anything at the destination, so retries succeed and the spurious `ERR_EXISTS` is gone. Genuine pre-existing files still return `ERR_EXISTS`. The overwrite path is unchanged. iRODS briefly locks the just-aborted replica, so the orphaned temp is removed by a deferred background cleanup (retry with backoff on a fresh connection).
- **Per-endpoint idle timeout** (`util/jetty.clj`, `core.clj`, `util/config.clj`): keep a short default idle timeout (`data-info.jetty.max-idle-time`, 200s) for all endpoints, but raise it (`data-info.jetty.upload-idle-time`, 1h) only for the streaming `/data` endpoints, via a Jetty `HttpConfiguration` customizer. Both values are configurable and applied per-request so keep-alive reuse stays correct.

## Testing

Reproduced and verified against the QA environment (terrain -> data-info -> iRODS):

- Interrupted upload → destination is **not** orphaned → retry **succeeds** (previously `ERR_EXISTS`).
- Uploading a name that genuinely exists → `ERR_EXISTS` still returned.
- Orphaned temp object self-cleans within ~30s.
- 210s stall during an upload → **HTTP 200** (previously `Idle timeout expired: 200000/200000 ms`).
- 31-minute steady 512 MB upload → **HTTP 200**, full file intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)